### PR TITLE
feat: split quizzes and add navigation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,110 +1,66 @@
 'use client'
 
 import { BlogCard } from '@/components/blog-card'
+import { RoadmapTimeline } from '@/components/roadmap-timeline'
 import { Button } from '@/components/ui/button'
 import { useLanguage } from '@/contexts/language-context'
 import { blogData } from '@/data/blog-data'
-import {
-    ArrowRight,
-    BookOpen,
-    Brain,
-    Globe,
-    Sparkles,
-} from 'lucide-react'
+import { roadmapEntries } from '@/data/hcm-roadmap'
+import { ArrowRight, BookOpen, Brain, Globe, Heart } from 'lucide-react'
 import Link from 'next/link'
 
 // Convert blog data to array format for homepage
-const blogs = Object.values(blogData)
-    .slice(0, 3)
-    .map((blog) => ({
-        id: blog.id,
-        section: blog.section,
-        title: blog.title,
-        excerpt: blog.excerpt,
-        author: blog.author,
-        date: blog.date,
-        readTime: blog.readTime,
-        image: blog.image,
-        originalLanguage: blog.originalLanguage,
-    }))
+const blogList = Object.values(blogData)
+
+const blogs = blogList.slice(0, 3).map((blog) => ({
+    id: blog.id,
+    section: blog.section,
+    title: blog.title,
+    excerpt: blog.excerpt,
+    author: blog.author,
+    date: blog.date,
+    readTime: blog.readTime,
+    image: blog.image,
+    originalLanguage: blog.originalLanguage,
+}))
 
 export default function HomePage() {
     const { t } = useLanguage()
+
+    const totalArticles = blogList.length
+    const totalQuizQuestions = blogList.reduce((sum, blog) => {
+        const questions = blog.quiz?.vietnamese?.length ?? 0
+        return sum + questions
+    }, 0)
 
     const chapterArticleCounts = Object.values(blogData).reduce<
         Record<string, number>
     >((acc, blog) => {
         const segments = blog.section.split('.')
-        const chapterId = segments.slice(0, 2).join('.') || blog.section
+        const chapterId = segments[0] || blog.section
         acc[chapterId] = (acc[chapterId] || 0) + 1
         return acc
     }, {})
 
     const chapterCards = [
         {
-            id: '4.1',
-            href: '/blogs?blog=4.1',
-            title: t('home.chapter41Title'),
-            description: t('home.chapter41Description'),
-            icon: BookOpen,
+            id: '6',
+            href: '/blogs?blog=6',
+            title: t('home.chapter6Title'),
+            description: t('home.chapter6Description'),
+            icon: Heart,
             gradient:
-                'from-purple-50 via-blue-50 to-indigo-50 dark:from-purple-900/20 dark:via-blue-900/20 dark:to-indigo-900/20',
-            border: 'border-purple-200/50 dark:border-purple-700/50',
-            floatingTop: 'from-purple-500/20 to-blue-500/20',
-            floatingBottom: 'from-indigo-500/15 to-purple-500/15',
-            iconGradient: 'from-purple-500 to-blue-600',
-            statsBg: 'bg-purple-100 dark:bg-purple-900/50',
-            statsText: 'text-purple-700 dark:text-purple-300',
-            titleHover:
-                'group-hover:text-purple-600 dark:group-hover:text-purple-400',
-            buttonHover:
-                'group-hover:bg-gradient-to-r group-hover:from-purple-500 group-hover:to-blue-600 group-hover:text-white group-hover:border-transparent',
-            buttonClasses:
-                'border-2 border-purple-200 text-purple-700 hover:text-white dark:border-purple-500 dark:text-purple-300',
-            shadow:
-                'hover:shadow-purple-500/25 dark:hover:shadow-purple-400/25',
-        },
-        {
-            id: '4.2',
-            href: '/blogs?blog=4.2',
-            title: t('home.chapter42Title'),
-            description: t('home.chapter42Description'),
-            icon: Globe,
-            gradient:
-                'from-emerald-50 via-green-50 to-teal-50 dark:from-emerald-900/20 dark:via-green-900/20 dark:to-teal-900/20',
-            border: 'border-emerald-200/50 dark:border-emerald-700/50',
-            floatingTop: 'from-emerald-500/20 to-teal-500/20',
-            floatingBottom: 'from-green-500/15 to-emerald-500/15',
-            iconGradient: 'from-emerald-500 to-teal-600',
-            statsBg: 'bg-emerald-100 dark:bg-emerald-900/50',
-            statsText: 'text-emerald-700 dark:text-emerald-300',
-            titleHover:
-                'group-hover:text-emerald-600 dark:group-hover:text-emerald-400',
-            buttonHover:
-                'group-hover:bg-gradient-to-r group-hover:from-emerald-500 group-hover:to-teal-600 group-hover:text-white group-hover:border-transparent',
-            buttonClasses:
-                'border-2 border-emerald-200 text-emerald-700 hover:text-white dark:border-emerald-500 dark:text-emerald-300',
-            shadow:
-                'hover:shadow-emerald-500/25 dark:hover:shadow-emerald-400/25',
-        },
-        {
-            id: '4.3',
-            href: '/blogs?blog=4.3',
-            title: t('home.chapter43Title'),
-            description: t('home.chapter43Description'),
-            icon: Sparkles,
-            gradient:
-                'from-rose-50 via-orange-50 to-yellow-50 dark:from-rose-900/20 dark:via-orange-900/20 dark:to-yellow-900/20',
+                'from-rose-50 via-amber-50 to-pink-50 dark:from-rose-900/20 dark:via-amber-900/20 dark:to-pink-900/20',
             border: 'border-rose-200/50 dark:border-rose-700/50',
-            floatingTop: 'from-rose-500/20 to-orange-500/20',
-            floatingBottom: 'from-yellow-500/15 to-rose-500/15',
-            iconGradient: 'from-rose-500 to-orange-500',
+            floatingTop: 'from-rose-500/25 to-amber-500/25',
+            floatingBottom: 'from-pink-500/20 to-rose-500/20',
+            iconGradient: 'from-rose-500 to-amber-500',
             statsBg: 'bg-rose-100 dark:bg-rose-900/50',
             statsText: 'text-rose-700 dark:text-rose-300',
             titleHover:
                 'group-hover:text-rose-600 dark:group-hover:text-rose-400',
             buttonHover:
-                'group-hover:bg-gradient-to-r group-hover:from-rose-500 group-hover:to-orange-500 group-hover:text-white group-hover:border-transparent',
+                'group-hover:bg-gradient-to-r group-hover:from-rose-500 group-hover:to-amber-500 group-hover:text-white group-hover:border-transparent',
             buttonClasses:
                 'border-2 border-rose-200 text-rose-700 hover:text-white dark:border-rose-500 dark:text-rose-300',
             shadow: 'hover:shadow-rose-500/25 dark:hover:shadow-rose-400/25',
@@ -173,7 +129,9 @@ export default function HomePage() {
                     <div className="flex justify-center space-x-8 text-sm text-muted-foreground animate-fade-in-up delay-800">
                         <div className="flex items-center group cursor-pointer">
                             <div className="w-3 h-3 bg-gradient-to-r from-green-400 to-emerald-500 rounded-full mr-2 group-hover:scale-125 transition-transform"></div>
-                            <span className="group-hover:text-emerald-600 dark:group-hover:text-emerald-400 transition-colors">5+ {t('home.articlesCount')}</span>
+                            <span className="group-hover:text-emerald-600 dark:group-hover:text-emerald-400 transition-colors">
+                                {totalArticles} {t('home.articlesCount')}
+                            </span>
                         </div>
                         <div className="flex items-center group cursor-pointer">
                             <div className="w-3 h-3 bg-gradient-to-r from-blue-400 to-cyan-500 rounded-full mr-2 group-hover:scale-125 transition-transform"></div>
@@ -186,6 +144,8 @@ export default function HomePage() {
                     </div>
                 </div>
             </section>
+
+            <RoadmapTimeline entries={roadmapEntries} />
 
             {/* Blogs Overview */}
             <section className="mt-20">
@@ -318,7 +278,7 @@ export default function HomePage() {
                                 <BookOpen className="h-12 w-12 text-purple-600 dark:text-purple-400 group-hover:scale-110 transition-transform duration-300" />
                             </div>
                             <h3 className="text-5xl font-bold bg-gradient-to-r from-purple-600 to-purple-800 dark:from-purple-400 dark:to-purple-600 bg-clip-text text-transparent mb-2 group-hover:scale-105 transition-transform duration-300">
-                                5+
+                                {totalArticles}
                             </h3>
                             <p className="text-muted-foreground text-lg font-medium">
                                 {t('home.articlesCount')}
@@ -348,7 +308,7 @@ export default function HomePage() {
                                 <Brain className="h-12 w-12 text-emerald-600 dark:text-emerald-400 group-hover:scale-110 transition-transform duration-300" />
                             </div>
                             <h3 className="text-5xl font-bold bg-gradient-to-r from-emerald-600 to-teal-800 dark:from-emerald-400 dark:to-teal-600 bg-clip-text text-transparent mb-2 group-hover:scale-105 transition-transform duration-300">
-                                20+
+                                {totalQuizQuestions}
                             </h3>
                             <p className="text-muted-foreground text-lg font-medium">
                                 {t('home.quizQuestions')}

--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -5,12 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useLanguage } from '@/contexts/language-context'
 import { philosophyBlogs, type ChapterId } from '@/data/philosophy-chapters'
-import {
-    BookOpen,
-    Building2,
-    Scale,
-    ArrowRight,
-} from 'lucide-react'
+import { ArrowRight, Heart } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import Link from 'next/link'
 
@@ -54,51 +49,19 @@ const statusColorMap: Record<QuizStatus, string> = {
 
 const chapterCards: ChapterCard[] = [
     {
-        chapterId: '4.1',
-        icon: BookOpen,
+        chapterId: '6',
+        icon: Heart,
         gradient:
-            'from-purple-50 to-blue-50 dark:from-purple-900/20 dark:to-blue-900/20',
-        border: 'border-purple-200 dark:border-purple-800',
-        accent: 'bg-purple-500/10',
-        iconBg: 'bg-purple-500',
-        buttonHover: 'group-hover:bg-purple-500 group-hover:text-white',
+            'from-rose-50 to-amber-50 dark:from-rose-900/20 dark:to-amber-900/20',
+        border: 'border-rose-200 dark:border-rose-800',
+        accent: 'bg-rose-500/10',
+        iconBg: 'bg-rose-500',
+        buttonHover: 'group-hover:bg-rose-500 group-hover:text-white',
         description: {
             vietnamese:
-                'Ôn tập khái niệm dân chủ, tiến trình hình thành và đặc trưng của dân chủ xã hội chủ nghĩa.',
+                'Ôn tập hệ chuẩn đạo đức Hồ Chí Minh, bảng so sánh đạo đức cách mạng và ý nghĩa với công tác cán bộ.',
             english:
-                'Review the foundations of democracy, its historical development, and the features of socialist democracy.',
-        },
-    },
-    {
-        chapterId: '4.2',
-        icon: Building2,
-        gradient:
-            'from-emerald-50 to-green-50 dark:from-emerald-900/20 dark:to-green-900/20',
-        border: 'border-emerald-200 dark:border-emerald-800',
-        accent: 'bg-emerald-500/10',
-        iconBg: 'bg-emerald-500',
-        buttonHover: 'group-hover:bg-emerald-500 group-hover:text-white',
-        description: {
-            vietnamese:
-                'Tổng hợp kiến thức về sự ra đời, bản chất, chức năng và vai trò của nhà nước xã hội chủ nghĩa.',
-            english:
-                'Consolidate knowledge about the emergence, nature, functions, and role of the socialist state.',
-        },
-    },
-    {
-        chapterId: '4.3',
-        icon: Scale,
-        gradient:
-            'from-amber-50 to-orange-50 dark:from-amber-900/20 dark:to-orange-900/20',
-        border: 'border-amber-200 dark:border-amber-800',
-        accent: 'bg-amber-500/10',
-        iconBg: 'bg-amber-500',
-        buttonHover: 'group-hover:bg-amber-500 group-hover:text-white',
-        description: {
-            vietnamese:
-                'Khám phá dân chủ xã hội chủ nghĩa và nhà nước pháp quyền xã hội chủ nghĩa trong thực tiễn Việt Nam hiện nay.',
-            english:
-                'Explore socialist democracy and the socialist rule-of-law state in contemporary Vietnam.',
+                "Revisit Hồ Chí Minh's ethical standards, compare revolutionary and ordinary morality, and link them to cadre development.",
         },
     },
 ]

--- a/components/roadmap-timeline.tsx
+++ b/components/roadmap-timeline.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { useState } from 'react'
+
+import { useLanguage } from '@/contexts/language-context'
+import { cn } from '@/lib/utils'
+
+import type { RoadmapData, RoadmapEntry } from '@/data/hcm-roadmap'
+
+type RoadmapTimelineProps = {
+    entries: RoadmapData
+}
+
+export function RoadmapTimeline({ entries }: RoadmapTimelineProps) {
+    const { currentLanguage, getLocalizedContent, t } = useLanguage()
+    const [activeId, setActiveId] = useState(entries[0]?.id ?? '')
+
+    const activeEntry = entries.find((entry) => entry.id === activeId)
+
+    if (!entries.length) {
+        return null
+    }
+
+    const renderLabel = (entry: RoadmapEntry) => {
+        return {
+            period: getLocalizedContent(entry.period),
+            stage: getLocalizedContent(entry.stage),
+        }
+    }
+
+    return (
+        <section className="mt-20">
+            <div className="text-center max-w-3xl mx-auto mb-12 animate-fade-in-up">
+                <h2 className="text-4xl font-bold mb-4 bg-gradient-to-r from-emerald-600 via-blue-600 to-purple-600 dark:from-emerald-300 dark:via-blue-300 dark:to-purple-300 bg-clip-text text-transparent">
+                    {t('home.roadmapTitle')}
+                </h2>
+                <p className="text-lg text-muted-foreground">
+                    {t('home.roadmapDescription')}
+                </p>
+                <p className="text-sm text-muted-foreground/70 mt-3">
+                    {t('home.roadmapHint')}
+                </p>
+            </div>
+
+            <div className="relative rounded-3xl border border-emerald-200/60 dark:border-emerald-900/40 bg-gradient-to-br from-emerald-50 via-blue-50 to-purple-50 dark:from-emerald-950/40 dark:via-slate-950/40 dark:to-purple-950/40 shadow-xl">
+                <div className="overflow-x-auto pb-8">
+                    <div className="relative flex min-w-max gap-12 px-8 py-12">
+                        <div className="pointer-events-none absolute left-8 right-8 top-1/2 h-px bg-gradient-to-r from-emerald-400 via-blue-400 to-purple-400 dark:from-emerald-500/60 dark:via-blue-500/60 dark:to-purple-500/60"></div>
+                        {entries.map((entry) => {
+                            const { period, stage } = renderLabel(entry)
+                            const isActive = entry.id === activeId
+
+                            return (
+                                <button
+                                    key={entry.id}
+                                    type="button"
+                                    onClick={() => setActiveId(entry.id)}
+                                    onMouseEnter={() => setActiveId(entry.id)}
+                                    className="relative z-10 flex flex-col items-center gap-3 outline-none group"
+                                    aria-pressed={isActive}
+                                >
+                                    <span
+                                        className={cn(
+                                            'text-sm font-medium text-muted-foreground transition-colors duration-300',
+                                            isActive &&
+                                                'text-emerald-600 dark:text-emerald-300 drop-shadow-sm'
+                                        )}
+                                    >
+                                        {period}
+                                    </span>
+                                    <span
+                                        className={cn(
+                                            'flex h-12 w-12 items-center justify-center rounded-full border-2 border-emerald-300/70 bg-white/80 dark:bg-emerald-950/70 backdrop-blur transition-all duration-300 group-focus-visible:ring-4 group-focus-visible:ring-emerald-400/50',
+                                            isActive
+                                                ? 'scale-110 border-emerald-500/90 shadow-lg shadow-emerald-500/30'
+                                                : 'hover:scale-105'
+                                        )}
+                                    >
+                                        <span
+                                            className={cn(
+                                                'h-3 w-3 rounded-full bg-emerald-400 transition-all duration-300',
+                                                isActive
+                                                    ? 'h-4 w-4 bg-emerald-500 shadow shadow-emerald-400/60'
+                                                    : 'group-hover:bg-emerald-500'
+                                            )}
+                                        ></span>
+                                    </span>
+                                    <span
+                                        className={cn(
+                                            'w-40 text-center text-xs font-semibold uppercase tracking-wide text-muted-foreground transition-colors duration-300',
+                                            isActive &&
+                                                'text-emerald-600 dark:text-emerald-300'
+                                        )}
+                                    >
+                                        {stage}
+                                    </span>
+                                </button>
+                            )
+                        })}
+                    </div>
+                </div>
+
+                {activeEntry && (
+                    <div className="border-t border-emerald-200/60 dark:border-emerald-900/40 bg-white/80 dark:bg-emerald-950/40 backdrop-blur px-8 py-10">
+                        <div className="grid gap-8 md:grid-cols-2">
+                            <div className="rounded-2xl bg-gradient-to-br from-emerald-100/80 via-emerald-50 to-white dark:from-emerald-900/40 dark:via-emerald-900/30 dark:to-emerald-950/60 p-6 shadow-md">
+                                <h3 className="text-base font-semibold text-emerald-700 dark:text-emerald-300 mb-2 uppercase tracking-wide">
+                                    {t('home.roadmapEventLabel')}
+                                </h3>
+                                <p className="text-sm leading-relaxed text-muted-foreground">
+                                    {activeEntry.event[currentLanguage]}
+                                </p>
+                            </div>
+                            <div className="rounded-2xl bg-gradient-to-br from-purple-100/80 via-blue-50 to-white dark:from-purple-900/40 dark:via-blue-900/30 dark:to-slate-950/60 p-6 shadow-md">
+                                <h3 className="text-base font-semibold text-purple-700 dark:text-purple-300 mb-2 uppercase tracking-wide">
+                                    {t('home.roadmapImpactLabel')}
+                                </h3>
+                                <p className="text-sm leading-relaxed text-muted-foreground">
+                                    {activeEntry.significance[currentLanguage]}
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                )}
+            </div>
+        </section>
+    )
+}

--- a/data/blog-data.ts
+++ b/data/blog-data.ts
@@ -3,1597 +3,742 @@ import type { SectionId } from './philosophy-chapters'
 export const blogData = {
     1: {
         id: 1,
-        section: '4.1.1' as SectionId,
+        section: '6.1' as SectionId,
         title: {
-            vietnamese: 'Dân chủ và sự ra đời, phát triển của dân chủ',
-            english: 'Democracy: Emergence and Development',
+            vietnamese: 'Đạo đức – gốc rễ của người cách mạng',
+            english: 'Ethics – the revolutionary foundation',
         },
         content: {
             vietnamese: `
+Chương 6: Tư tưởng Hồ Chí Minh về văn hóa, đạo đức, con người
 
+1. Đạo đức là gốc, là nền tảng tinh thần của xã hội, của người cách mạng
 
-## I. Dân chủ và dân chủ xã hội chủ nghĩa
+Đạo đức là nguồn nuôi dưỡng, phát triển con người
+- Hồ Chí Minh khẳng định: “Đạo đức là nguồn nuôi dưỡng và phát triển con người.” Hay “Đạo đức là gốc, là nền tảng, là sức mạnh, là tiêu chuẩn hàng đầu của người cách mạng”.
+- Đạo đức giống như chất dinh dưỡng nuôi lớn tâm hồn, phẩm chất, nhân cách mỗi người trong xã hội.
 
-### 1. Dân chủ và sự ra đời, phát triển của dân chủ
+Đạo đức là gốc của người cách mạng
+- Đạo đức được Bác ví như cái gốc của cây. Nếu cây không có gốc sẽ héo, con người không có đạo đức thì cũng không thể trưởng thành, không thể làm cách mạng.
+- “Cũng như sông thì có nguồn mới có nước, không có nguồn thì sông cạn. Cây phải có gốc, không có gốc thì cây héo. Người cách mạng phải có đạo đức, không có đạo đức thì giỏi mấy cũng không lãnh đạo được nhân dân.” (Sửa đổi lối làm việc, 1947).
 
-#### 1.1. Quan niệm về dân chủ
+Đạo đức là nền tảng của người cách mạng
+- Đạo đức chính là nền móng vững chắc giúp người cách mạng đứng vững trước mọi thử thách, gian khổ.
+- Nhờ có nền tảng đạo đức vững, cán bộ mới giữ được lòng kiên định, không bị sa ngã.
+- Trong tác phẩm Đạo đức cách mạng (1958), Hồ Chí Minh viết: “Làm cách mạng để cải tạo xã hội cũ thành xã hội mới là một sự nghiệp rất vẻ vang, nhưng nó cũng là một nhiệm vụ rất nặng nề, một cuộc đấu tranh rất phức tạp, lâu dài, gian khổ. Sức có mạnh mới gánh được nặng và đi được xa. Người cách mạng phải có đạo đức cách mạng làm nền tảng, mới hoàn thành được nhiệm vụ cách mạng vẻ vang.”
 
-##### 1.1.1. Dân chủ trong lịch sử nhân loại
-Thuật ngữ dân chủ (demokratos) xuất hiện từ thế kỷ VII – VI TCN ở Hy Lạp cổ đại, trong đó *demos* nghĩa là nhân dân và *kratos* nghĩa là cai trị. Như vậy, dân chủ được hiểu là “nhân dân cai trị”, hay “quyền lực thuộc về nhân dân”. Tuy nhiên, giữa dân chủ cổ đại và dân chủ hiện đại có sự khác biệt căn bản: ở thời cổ đại, dân chủ mang tính trực tiếp, gắn với phạm vi hẹp và khái niệm “nhân dân” chỉ bao gồm một bộ phận giai cấp tự do, trong khi nô lệ – chiếm đa số – không có quyền làm chủ.
+Đạo đức là tiêu chuẩn hàng đầu của người cách mạng
+- Đạo đức là “tiêu chuẩn hàng đầu” để đánh giá cán bộ, đảng viên.
+- Nhân dân chỉ quý mến, tin tưởng những người có tư cách, đạo đức thật sự.
+- “Trước mặt quần chúng, không phải ta cứ viết lên trán chữ ‘cộng sản’ mà ta được họ yêu mến. Quần chúng chỉ quý mến những người có tư cách, đạo đức.”
 
-Từ góc nhìn lịch sử, dân chủ luôn gắn với sự hình thành, tồn tại và phát triển của nhà nước. Nó vừa là hình thức tổ chức quyền lực công cộng, vừa là giá trị xã hội phản ánh khát vọng tự do, bình đẳng của con người.
+Đạo đức là sức mạnh của người cách mạng
+- Đạo đức trở thành nhân tố quyết định của sự thành bại của mọi công việc, phẩm chất mỗi con người.
+- “Người cán bộ cách mạng phải có đạo đức cách mạng ... Mọi việc thành hay là bại, chủ chốt do cán bộ có thấm nhuần đạo đức cách mạng, hay là không.” (Người cán bộ cách mạng).
+- Đạo đức cách mạng là chỗ dựa giúp cho con người vững vàng trong mọi thử thách.
+- “Có đạo đức cách mạng thì khi gặp khó khăn, gian khổ, thất bại, cũng không sợ sệt, rụt rè, lùi bước... Khi gặp thuận lợi và thành công vẫn giữ tinh thần gian khổ, chất phác, khiêm tốn.” (Hồ Chí Minh: Toàn tập, Nxb Chính trị quốc gia, Hà Nội, 2011, t.11, tr.602-603).
 
-##### 1.1.2. Quan niệm dân chủ trong triết học Mác – Lênin
-Các nhà sáng lập chủ nghĩa Mác – Lênin khẳng định:
+Đạo đức phải thể hiện trong hành động, lấy hiệu quả thực tế làm thước đo
+- Đạo đức không chỉ nằm ở lời nói hay những nguyên tắc lý thuyết suông, mà phải thể hiện rõ trong hành động, trong kết quả phục vụ nhân dân.
+- Muốn đánh giá một người có đạo đức hay không, phải nhìn vào hiệu quả thực tế việc làm, cống hiến của họ. “Nói đi đôi với làm”, “lấy hiệu quả phục vụ nhân dân làm thước đo” là chuẩn mực cao nhất của đạo đức.
+- Luôn đặt đạo đức bên cạnh tài năng, gắn đức với tài, lời nói đi đôi với hành động và hiệu quả trên thực tế.
 
-- Dân chủ là sản phẩm của đấu tranh giai cấp cho những giá trị tiến bộ.
-- Dân chủ là một hình thức tổ chức nhà nước của giai cấp cầm quyền.
-- Dân chủ cũng là nguyên tắc trong tổ chức và quản lý xã hội.
+Vai trò của đạo đức
+- Đạo đức còn là thước đo lòng cao thượng của con người.
+- “Tuy năng lực và công việc của mỗi người khác nhau, người làm việc to, người làm việc nhỏ; nhưng ai giữ được đạo đức đều là người cao thượng.”
+- Thực hành tốt đạo đức cá nhân không chỉ tôn vinh giá trị của mình mà còn tạo ra sức mạnh nội sinh giúp ta vượt qua mọi thử thách.
 
-Từ đó, dân chủ theo quan điểm Mác – Lênin có ba nội dung cơ bản:
-
-- **Về quyền lực**: dân chủ là quyền lực thuộc về nhân dân, nhân dân là chủ nhân của nhà nước, quyền lực nhà nước phải phục vụ nhân dân.
-- **Về chế độ chính trị**: dân chủ là một hình thái nhà nước, một chế độ xã hội cụ thể.
-- **Về nguyên tắc quản lý**: dân chủ là nguyên tắc cơ bản, kết hợp với nguyên tắc tập trung để hình thành nguyên tắc tập trung dân chủ.
-
-Chủ nghĩa Mác – Lênin coi dân chủ vừa là mục tiêu, vừa là phương tiện để đi đến tự do, giải phóng con người và giải phóng xã hội. Với tư cách là một hình thái chính trị – nhà nước, dân chủ mang tính lịch sử, ra đời cùng nhà nước và sẽ mất đi khi nhà nước tiêu vong. Nhưng với tư cách là một giá trị xã hội, dân chủ có tính vĩnh viễn, tồn tại cùng với sự phát triển của loài người.
-
-##### 1.1.3. Tư tưởng Hồ Chí Minh về dân chủ
-Trên nền tảng Mác – Lênin, Hồ Chí Minh phát triển tư tưởng dân chủ theo hướng:
-
-- Dân chủ là giá trị nhân loại chung: “Dân chủ là dân là chủ và dân làm chủ”.
-- Dân chủ là một thể chế chính trị: Nhà nước dân chủ là nhà nước “do dân làm chủ”, chính phủ chỉ là “người đầy tớ trung thành của nhân dân”.
-- Dân chủ phải bảo đảm mọi quyền lực thuộc về nhân dân, nhân dân làm chủ toàn diện: nhà nước, xã hội, kinh tế, văn hóa – tinh thần.
-
-Đảng Cộng sản Việt Nam, kế thừa và phát triển tư tưởng Hồ Chí Minh, xác định xây dựng chế độ dân chủ xã hội chủ nghĩa, phát huy quyền làm chủ của nhân dân, gắn dân chủ với công bằng xã hội, kỷ luật và pháp luật.
-
-#### 1.2. Sự ra đời và phát triển của dân chủ
-
-##### 1.2.1. Dân chủ nguyên thủy
-Trong xã hội cộng sản nguyên thủy, các hình thức dân chủ sơ khai xuất hiện dưới dạng “dân chủ quân sự”. Thông qua “Đại hội nhân dân”, cộng đồng bầu ra thủ lĩnh quân sự, mọi người có quyền phát biểu và biểu quyết. Tuy nhiên, dân chủ thời kỳ này gắn liền với trình độ sản xuất thấp và còn rất hạn chế.
-
-##### 1.2.2. Dân chủ chủ nô
-Khi chế độ chiếm hữu nô lệ hình thành, dân chủ nguyên thủy tan rã, nhường chỗ cho nền dân chủ chủ nô. Mặc dù có hình thức nhân dân tham gia bầu cử và quyết định công việc nhà nước, nhưng “nhân dân” chỉ bao gồm giai cấp chủ nô và một số công dân tự do. Đại đa số là nô lệ không có quyền. Bản chất của nền dân chủ này là dân chủ cho thiểu số.
-
-##### 1.2.3. Dân chủ tư sản
-Từ cuối thế kỷ XIV – XV, cùng với sự suy tàn của chế độ phong kiến và sự vươn lên của giai cấp tư sản, những mầm mống của dân chủ tư sản đã xuất hiện. Đến thế kỷ XVII – XVIII, thông qua các cuộc cách mạng tư sản, dân chủ tư sản chính thức hình thành và phát triển, mở ra bước tiến mới với những giá trị tiến bộ về tự do, bình đẳng và dân chủ. Tuy nhiên, do được xây dựng trên cơ sở chế độ tư hữu tư liệu sản xuất, dân chủ tư sản trên thực tế vẫn chỉ là dân chủ của giai cấp tư sản, nhằm bảo vệ lợi ích của những người sở hữu tư bản.
-
-##### 1.2.4. Dân chủ xã hội chủ nghĩa
-Cách mạng Tháng Mười Nga năm 1917 mở ra một thời đại mới: nhân dân lao động giành được quyền lực, xây dựng nhà nước công – nông, thiết lập nền dân chủ vô sản – tức dân chủ xã hội chủ nghĩa. Đây là nền dân chủ của đại đa số nhân dân, nhằm bảo vệ lợi ích của người lao động, thực hiện quyền làm chủ toàn diện của nhân dân.
-
-Đặc trưng của dân chủ xã hội chủ nghĩa bao gồm:
-
-- Quyền lực thuộc về nhân dân, nhân dân làm chủ nhà nước và xã hội.
-- Thực hiện dân chủ toàn diện trên tất cả các lĩnh vực: chính trị, kinh tế, văn hóa, xã hội.
-- Dân chủ gắn với kỷ luật, pháp luật và công bằng xã hội.
-
-![Minh họa dân chủ xã hội chủ nghĩa](/assets/blog-images/4.1.1.png)
-
-#### 1.3. Bản chất và ý nghĩa của dân chủ xã hội chủ nghĩa
-
-##### 1.3.1. Bản chất
-- Là nền dân chủ của đại đa số nhân dân lao động.
-- Bảo đảm sự thống nhất giữa quyền con người, quyền công dân với lợi ích chung của xã hội.
-- Gắn liền với nguyên tắc tập trung dân chủ trong tổ chức và quản lý xã hội.
-
-##### 1.3.2. Ý nghĩa
-- Tạo ra cơ sở chính trị – xã hội để bảo đảm quyền lực thực sự thuộc về nhân dân.
-- Thúc đẩy sự phát triển toàn diện của xã hội gắn với tự do, công bằng, bình đẳng.
-- Là công cụ để bảo vệ quyền lợi nhân dân, đồng thời là mục tiêu để xây dựng xã hội xã hội chủ nghĩa.
-
-#### 1.4. Kết luận
-Dân chủ, xét từ góc độ triết học Mác – Lênin, là một phạm trù lịch sử – chính trị gắn liền với sự hình thành và phát triển của các nhà nước trong lịch sử nhân loại. Qua các giai đoạn, dân chủ biến đổi từ dân chủ nguyên thủy, dân chủ chủ nô, dân chủ tư sản cho đến dân chủ xã hội chủ nghĩa.
-
-Trong đó, dân chủ xã hội chủ nghĩa là hình thức dân chủ cao nhất, mang bản chất nhân dân sâu sắc, thể hiện quyền làm chủ toàn diện của đại đa số người lao động. Đó vừa là mục tiêu, vừa là động lực để xây dựng xã hội mới – xã hội công bằng, dân chủ, văn minh.
+Những phẩm chất thống nhất của con người
+- Trong tư tưởng đạo đức Hồ Chí Minh: “Đức và tài, hồng và chuyên, phẩm chất và năng lực phải thống nhất.”
+- Đạo đức là tiêu chuẩn cho mục đích hành động: “Hồng” = Đức, gắn với lý tưởng cách mạng, lòng yêu nước, yêu chủ nghĩa xã hội, sự trong sáng về đạo đức.
+- Tài là phương tiện thực hiện mục đích đó: “Chuyên” = Tài, nghĩa là chuyên môn, nghiệp vụ, kỹ năng nghề nghiệp; người “có chuyên” làm việc hiệu quả, đem lại lợi ích cho tập thể, cho nhân dân.
+- Con người cần có cả đức và tài; thiếu tài thì làm việc gì cũng khó, nhưng thiếu đạo đức thì vô dụng, thậm chí có hại.
 `,
             english: `
+Chapter 6: Hồ Chí Minh's Thought on Culture, Ethics, and Humanity
 
+1. Ethics are the root and spiritual foundation of society and revolutionaries
 
-## I. Democracy and Socialist Democracy
+Ethics nourish and develop human beings
+- Hồ Chí Minh affirmed: “Ethics nourish and develop human beings.” He also emphasised that “Ethics are the root, the foundation, the strength, and the foremost standard for revolutionaries.”
+- Ethics resemble nutrients that nurture each person’s soul, qualities, and character within society.
 
-### 1. Democracy and Its Emergence and Development
+Ethics are the root of revolutionaries
+- He compared ethics to a tree’s roots. Without roots a tree withers; without ethics a person cannot mature or undertake revolution.
+- “As a river must have a source to have water; without a source the river dries up. Trees must have roots; without roots they wither. Revolutionaries must possess ethics; without ethics, no matter how talented, they cannot lead the people.” (Correcting Working Style, 1947).
 
-#### 1.1. Understanding Democracy
+Ethics form the revolutionary foundation
+- Ethics provide the firm footing that allows revolutionaries to withstand every trial and hardship.
+- Thanks to solid moral foundations, cadres remain steadfast and avoid moral decline.
+- In Revolutionary Ethics (1958) he wrote: “Making revolution to transform the old society into a new one is a glorious cause, yet it is also a heavy task, a complex, prolonged, arduous struggle. Only with great strength can one shoulder heavy burdens and go far. Revolutionaries must take revolutionary ethics as their foundation to fulfil their glorious mission.”
 
-##### 1.1.1. Democracy in Human History
-The term democracy (*demokratos*) appeared in the 7th–6th centuries BCE in ancient Greece, where *demos* means the people and *kratos* means rule. Democracy therefore means “rule by the people” or “power belongs to the people.” Yet ancient democracy and modern democracy differ fundamentally: in antiquity it was direct, confined to a narrow scope, and the concept of “the people” only covered a portion of the free classes, while the enslaved majority had no political rights.
+Ethics are the foremost standard for revolutionaries
+- Ethics are the “foremost standard” for evaluating cadres and Party members.
+- People admire and trust only those who truly have moral integrity.
+- “Before the masses, writing the word ‘communist’ on our forehead does not make them love us. The masses cherish only those who possess true ethics.”
 
-From a historical perspective, democracy is inseparable from the formation, existence, and development of the state. It is both a form of organizing public power and a social value that reflects humanity’s aspiration for freedom and equality.
+Ethics are the strength of revolutionaries
+- Ethics become the decisive factor behind the success or failure of every task and each person’s character.
+- “A revolutionary cadre must have revolutionary ethics ... Whether work succeeds or fails depends primarily on whether cadres imbue revolutionary ethics.” (Revolutionary Cadre).
+- Revolutionary ethics are the pillar that helps people remain steadfast through every trial.
+- “With revolutionary ethics, when facing difficulties, hardships, or defeat, one does not feel fear or withdraw... When meeting favourable conditions and success, one still maintains the spirit of hardship, simplicity, and humility.” (Collected Works, vol.11, pp.602-603).
 
-##### 1.1.2. Democracy in Marxism–Leninism
-The founders of Marxism–Leninism affirmed that:
+Ethics must appear in action; practical effectiveness is the measure
+- Ethics cannot remain mere words or theoretical principles; they must manifest clearly in action and in serving the people.
+- To judge whether someone is ethical, examine the tangible outcomes of their work and dedication. “Words must match deeds” and “effectiveness in serving the people is the measure” are the highest standards of ethics.
+- Ethics must always accompany talent so that words, actions, and real-world impact align.
 
-- Democracy is the product of class struggle for progressive values.
-- Democracy is a form of state organization exercised by the ruling class.
-- Democracy is also a principle for organizing and governing society.
+The role of ethics
+- Ethics are also the yardstick of human nobility.
+- “Although everyone’s abilities and work differ—some undertake great tasks, others small—whoever preserves ethics is noble.”
+- Practising personal ethics not only honours one’s value but also builds inner strength to overcome challenges.
 
-Accordingly, Marxism–Leninism highlights three key aspects of democracy:
-
-- **On power:** democracy means power belongs to the people; the people are the owners of the state and state power must serve them.
-- **On the political system:** democracy is a concrete state form and a specific social regime.
-- **On governance principles:** democracy is a foundational principle that combines with centralization to form the principle of democratic centralism.
-
-Marxism–Leninism treats democracy as both goal and means for achieving freedom and the liberation of human beings and society. As a political–state form, democracy is historical: it arose with the state and will disappear when the state withers away. As a social value, however, democracy has a lasting character that accompanies the development of humankind.
-
-##### 1.1.3. Hồ Chí Minh’s Conception of Democracy
-On the basis of Marxism–Leninism, Hồ Chí Minh developed the concept of democracy in the following directions:
-
-- Democracy is a universal human value: “Democracy means the people are the masters and the people exercise mastery.”
-- Democracy is a political institution: a democratic state is a state “of the people,” and the government is merely “the loyal servant of the people.”
-- Democracy must ensure that all power belongs to the people, who exercise comprehensive mastery over the state, society, economy, and cultural–spiritual life.
-
-The Communist Party of Vietnam inherits and advances Hồ Chí Minh’s thought by building socialist democracy, promoting the people’s mastery, and linking democracy with social justice, discipline, and the rule of law.
-
-#### 1.2. The Emergence and Development of Democracy
-
-##### 1.2.1. Primitive Democracy
-In primitive communal society, rudimentary democratic forms appeared as “military democracy.” Through people’s assemblies, communities elected military leaders and everyone could speak and vote. Nonetheless, democracy in this period was limited by low productive forces and remained quite restricted.
-
-##### 1.2.2. Slave-Owning Democracy
-When the slave-owning system emerged, primitive democracy disintegrated and was replaced by slave-owning democracy. Although citizens could vote and decide on public affairs, “the people” referred only to slave owners and certain free citizens. The vast majority—slaves—had no rights, so this democracy was essentially for a minority.
-
-##### 1.2.3. Bourgeois Democracy
-From the late 14th–15th centuries, as feudalism declined and the bourgeoisie rose, the seeds of bourgeois democracy appeared. By the 17th–18th centuries, bourgeois revolutions established and developed bourgeois democracy, ushering in advances in freedom, equality, and democratic rights. Yet because it rests on private ownership of the means of production, bourgeois democracy in practice remains the democracy of the bourgeoisie, protecting the interests of capital owners.
-
-##### 1.2.4. Socialist Democracy
-The Russian October Revolution of 1917 opened a new era in which working people seized power, built a workers’ and peasants’ state, and established proletarian democracy—socialist democracy. This is democracy for the vast majority, safeguarding workers’ interests and enabling them to exercise comprehensive mastery.
-
-Key features of socialist democracy include:
-
-- Power belongs to the people, who master the state and society.
-- Democracy is practiced comprehensively in politics, economics, culture, and society.
-- Democracy goes hand in hand with discipline, law, and social justice.
-
-![Illustration of socialist democracy](/assets/blog-images/4.1.1.png)
-
-#### 1.3. Nature and Significance of Socialist Democracy
-
-##### 1.3.1. Nature
-- It is democracy for the overwhelming majority of working people.
-- It ensures unity between human rights, citizens’ rights, and the common interests of society.
-- It is bound to the principle of democratic centralism in social organization and management.
-
-##### 1.3.2. Significance
-- It creates the political and social foundation that guarantees power truly belongs to the people.
-- It drives comprehensive social development in conjunction with freedom, justice, and equality.
-- It is both an instrument for protecting the people’s interests and a goal in building a socialist society.
-
-#### 1.4. Conclusion
-From a Marxist–Leninist philosophical perspective, democracy is a historical-political category linked to the formation and development of states throughout human history. Democracy has evolved through the stages of primitive, slave-owning, bourgeois, and socialist democracy.
-
-Among them, socialist democracy represents the highest form of democracy, profoundly embodying the people’s nature and expressing the comprehensive mastery of the working majority. It is both the goal and the driving force for building a new society—one that is equitable, democratic, and civilized.
+Unified human qualities
+- In Hồ Chí Minh’s ethical thought: “Virtue and talent, redness and expertness, qualities and capacity must be unified.”
+- Ethics guide the purpose of action: “Redness” equals virtue, linked to revolutionary ideals, patriotism, socialism, and moral purity.
+- Talent realises that purpose: “Expertness” equals ability—professional knowledge, expertise, and skills; those “with expertness” work effectively for the collective and the people.
+- People need both virtue and talent; without talent, work is difficult, but without ethics, talent is useless or even harmful.
 `,
         },
         excerpt: {
             vietnamese:
-                'Giải thích khái niệm, quá trình hình thành và ý nghĩa của dân chủ xã hội chủ nghĩa từ quan điểm Mác – Lênin và Hồ Chí Minh.',
+                'Khẳng định đạo đức là gốc rễ, sức mạnh và thước đo phẩm chất của người cách mạng trong tư tưởng Hồ Chí Minh.',
             english:
-                'Explains the concept, historical formation, and significance of socialist democracy from Marxist-Leninist and Hồ Chí Minh perspectives.',
+                'Affirms ethics as the root, strength, and measure of revolutionary character in Hồ Chí Minh’s thought.',
         },
         author: 'Admin',
-        date: '2024-05-15',
+        date: '2024-11-15',
         readTime: {
-            vietnamese: '20 phút',
-            english: '20 minutes',
-        },
-        image: '/assets/blog-images/4.1.1-thumbnail.png',
-        originalLanguage: 'vietnamese' as const,
-        quiz: {
-            vietnamese: [
-                {
-                    question: 'Thuật ngữ “demokratos” (demos + kratos) được hiểu đúng nhất là gì?',
-                    options: [
-                        'Thiểu số cai trị đa số',
-                        'Quyền lực thuộc về nhân dân (nhân dân cai trị)',
-                        'Quyền lực thuộc về quý tộc',
-                        'Quyền lực thuộc về tôn giáo',
-                    ],
-                    correct: 1,
-                },
-                {
-                    question: 'Điểm khác biệt căn bản giữa dân chủ cổ đại và dân chủ hiện đại là gì?',
-                    options: [
-                        'Cổ đại dùng bầu cử, hiện đại không',
-                        'Cổ đại mang tính trực tiếp, phạm vi hẹp, loại trừ nô lệ; hiện đại mở rộng quyền cho toàn dân',
-                        'Cổ đại có tam quyền, hiện đại không',
-                        'Cổ đại không có pháp luật, hiện đại mới có',
-                    ],
-                    correct: 1,
-                },
-                {
-                    question: 'Theo Mác – Lênin, nguyên tắc tổ chức gắn với dân chủ để hình thành cơ chế quản lý là gì?',
-                    options: [
-                        'Tập quyền tuyệt đối',
-                        'Pháp trị thuần túy',
-                        'Tập trung dân chủ',
-                        'Phân quyền cứng',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'Theo tư tưởng Hồ Chí Minh, chính phủ trong nhà nước dân chủ phải là gì?',
-                    options: [
-                        'Cơ quan cai trị tối cao, trên nhân dân',
-                        'Người đầy tớ trung thành của nhân dân',
-                        'Tổ chức độc lập với nhân dân',
-                        'Đại diện cho giới chủ tư bản',
-                    ],
-                    correct: 1,
-                },
-                {
-                    question: 'Thực tiễn nào đánh dấu việc nền dân chủ xã hội chủ nghĩa được xác lập ở tầm nhà nước?',
-                    options: [
-                        'Cách mạng Tư sản Anh (1688)',
-                        'Công xã Pari (1871)',
-                        'Cách mạng Tháng Mười Nga và sự ra đời Nhà nước Xô viết (1917)',
-                        'Cách mạng Tháng Tám Việt Nam (1945)',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'Đâu KHÔNG phải là đặc trưng của dân chủ xã hội chủ nghĩa?',
-                    options: [
-                        'Quyền lực thuộc về nhân dân, dân làm chủ nhà nước và xã hội',
-                        'Dân chủ toàn diện trên chính trị, kinh tế, văn hóa, xã hội',
-                        'Dân chủ gắn với kỷ luật, pháp luật và công bằng xã hội',
-                        'Đa đảng đối lập là điều kiện bắt buộc để thực hiện dân chủ',
-                    ],
-                    correct: 3,
-                },
-            ],
-            english: [
-                {
-                    question: 'What is the most accurate meaning of the term “demokratos” (demos + kratos)?',
-                    options: [
-                        'A minority rules the majority',
-                        'Power belongs to the people (the people rule)',
-                        'Power belongs to the aristocracy',
-                        'Power belongs to religion',
-                    ],
-                    correct: 1,
-                },
-                {
-                    question: 'What is the fundamental difference between ancient and modern democracy?',
-                    options: [
-                        'Ancient societies used elections, modern ones do not',
-                        'Ancient democracy was direct, narrow in scope, and excluded slaves; modern democracy expands rights to the whole people',
-                        'Ancient democracy had separation of powers while modern democracy does not',
-                        'Ancient societies lacked law and only modern times created it',
-                    ],
-                    correct: 1,
-                },
-                {
-                    question: 'According to Marx and Lenin, which organizing principle combines with democracy to form the management mechanism?',
-                    options: [
-                        'Absolute centralization',
-                        'Pure rule of law',
-                        'Democratic centralism',
-                        'Rigid separation of powers',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'In Hồ Chí Minh’s thought, what must a government in a democratic state be?',
-                    options: [
-                        'The supreme ruling body above the people',
-                        'The loyal servant of the people',
-                        'An organization independent from the people',
-                        'A representative of the capitalist class',
-                    ],
-                    correct: 1,
-                },
-                {
-                    question: 'Which historical event marked the establishment of socialist democracy at the state level?',
-                    options: [
-                        'The English Glorious Revolution (1688)',
-                        'The Paris Commune (1871)',
-                        'The October Revolution and the birth of the Soviet state (1917)',
-                        'The August Revolution in Vietnam (1945)',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'Which of the following is NOT a characteristic of socialist democracy?',
-                    options: [
-                        'Power belongs to the people, who master the state and society',
-                        'Democracy is comprehensive across politics, economics, culture, and society',
-                        'Democracy is tied to discipline, law, and social justice',
-                        'An opposing multi-party system is an indispensable condition for democracy',
-                    ],
-                    correct: 3,
-                },
-            ],
-        },
-    },
-    2: {
-        id: 2,
-        section: '4.1.2' as SectionId,
-        title: {
-            vietnamese: 'Dân chủ xã hội chủ nghĩa',
-            english: 'Socialist Democracy',
-        },
-        content: {
-            vietnamese: `
-# Dân chủ xã hội chủ nghĩa
-
-## 2.1. Mô tả
-Dân chủ là một phạm trù vừa mang tính lịch sử, vừa là giá trị xã hội. Trên cơ sở nghiên cứu lịch sử các chế độ và tổng kết kinh nghiệm thực tiễn, chủ nghĩa Mác – Lênin khẳng định dân chủ là sản phẩm của đấu tranh giai cấp và biến đổi theo từng hình thái kinh tế – xã hội. Trong tiến trình đó, dân chủ xã hội chủ nghĩa xuất hiện như một hình thái dân chủ cao hơn về chất so với dân chủ tư sản, với mục tiêu thực hiện quyền làm chủ thực sự của đại đa số nhân dân lao động.
-
-### 2.1.1. Kế thừa và vượt lên từ nền dân chủ trước đó
-Từ góc độ lịch sử, các nhà sáng lập Mác – Lênin nhận xét rằng đấu tranh cho dân chủ là một quá trình lâu dài, nhiều giai đoạn. Dân chủ tư sản đem lại nhiều giá trị tiến bộ (tự do, bình đẳng, pháp quyền), nhưng vì được xây dựng trên nền tảng sở hữu tư nhân về tư liệu sản xuất nên vẫn là “dân chủ của thiểu số”. Trên cơ sở phân tích này, chủ nghĩa Mác – Lênin dự đoán và chỉ ra tính tất yếu xuất hiện một nền dân chủ mới, cao hơn về chất: dân chủ vô sản (dân chủ xã hội chủ nghĩa).
-
-### 2.1.2. Tiền đề thực tiễn: từ Công xã Pari đến Cách mạng Tháng Mười
-Ý tưởng về dân chủ vô sản đã phôi thai từ các phong trào và thực tiễn đấu tranh giai cấp – tiêu biểu là Công xã Pari (1871). Song chỉ khi Cách mạng Tháng Mười (1917) thành công, với việc thành lập Nhà nước Xô viết – nhà nước xã hội chủ nghĩa đầu tiên – thì nền dân chủ xã hội chủ nghĩa mới chính thức được xác lập trên quy mô chính quyền và thể chế. Sự ra đời này đánh dấu bước chuyển đổi về chất trong lịch sử dân chủ: từ quyền lực của thiểu số sang quyền lực thực sự hướng tới đại đa số lao động.
-
-
-
-![Thiết lập nhà nước Xô viết đầu tiên](/assets/blog-images/4.1.2-2.png)
-
-### 2.1.3. Tiến trình phát triển
-Triết học Mác – Lênin nhấn mạnh rằng nền dân chủ xã hội chủ nghĩa phát triển từ thấp tới cao, từ chưa hoàn thiện tới hoàn thiện, đồng thời kế thừa có chọn lọc các giá trị tích cực của nền dân chủ trước đó. Quá trình hoàn thiện dân chủ xã hội chủ nghĩa bao gồm mở rộng quyền làm chủ của quần chúng, nâng cao tính tự giác và sự tham gia quản lý của nhân dân. Khi dân chủ được mở rộng đến mức rộng rãi và sâu sắc, tính “chính trị” của nhà nước (vốn là công cụ của giai cấp) dần mất đi – nghĩa là nhà nước với tư cách công cụ giai cấp sẽ “tiêu vong” trên đường tới xã hội cộng sản.
-![Từ Công xã Pari đến Cách mạng Tháng Mười](/assets/blog-images/4.1.2-1.png)
-## 2.2. Bản chất của nền dân chủ xã hội chủ nghĩa
-Dân chủ xã hội chủ nghĩa có bản chất đa diện, được phân tích ở các bình diện chính trị, kinh tế, tư tưởng – văn hóa – xã hội và pháp quyền.
-
-### 2.2.1. Bản chất chính trị
-- Quyền lực thuộc về nhân dân lao động: dân chủ xã hội chủ nghĩa là dân chủ của đại đa số – những người lao động từng bị bóc lột – chứ không phải dân chủ cho mọi giai cấp theo nghĩa bình đẳng tuyệt đối giữa giai cấp thống trị và bị trị trong chế độ tư sản.
-- Vai trò lãnh đạo của Đảng Cộng sản: sự lãnh đạo chính trị duy nhất của một Đảng đại diện cho giai cấp công nhân là nhân tố quyết định để đảm bảo quyền lực thực sự thuộc về nhân dân. Theo quan điểm Mác – Lênin và Hồ Chí Minh, Đảng có chức năng tập hợp, giác ngộ và tổ chức quần chúng nhằm thực hiện quyền làm chủ; do đó dân chủ xã hội chủ nghĩa mang tính nhất nguyên về chính trị nhưng hướng tới lợi ích toàn dân.
-- Tập trung dân chủ: nguyên tắc kết hợp giữa tập trung và dân chủ (tập trung dân chủ) là phương thức tổ chức quản lý, đảm bảo thống nhất hành động đồng thời tạo không gian cho sự tham gia của quần chúng.
-
-### 2.2.2. Bản chất kinh tế
-- Sở hữu xã hội về tư liệu sản xuất chủ yếu: nền dân chủ xã hội chủ nghĩa dựa trên chế độ sở hữu xã hội đối với những tư liệu sản xuất chủ yếu; đây là điều kiện để bảo đảm quyền làm chủ thực sự của nhân dân đối với các nguồn lực kinh tế.
-- Phân phối theo lao động là chủ yếu: việc phân phối lợi ích đặt trọng tâm vào kết quả lao động, hướng tới giảm bất công và bảo đảm ngày càng cao đời sống vật chất cho toàn dân.
-- Quá trình lịch sử và điều kiện vật chất: bản chất kinh tế này chỉ bộc lộ đầy đủ qua một quá trình ổn định chính trị, phát triển sản xuất và nâng cao trình độ lực lượng sản xuất.
-
-### 2.2.3. Bản chất tư tưởng – văn hóa – xã hội
-- Hệ tư tưởng Mác – Lênin giữ vai trò chủ đạo nhưng tiếp thu giá trị văn hóa dân tộc và tiến bộ nhân loại.
-- Phát triển con người toàn diện: dân chủ trong lĩnh vực văn hóa – tư tưởng tạo điều kiện nâng cao tri thức, nuôi dưỡng sáng tạo và phát triển nhân cách.
-- Hòa hợp lợi ích cá nhân – tập thể – xã hội thông qua hệ thống chính sách và tổ chức xã hội.
-
-### 2.2.4. Bản chất pháp quyền
-Nhà nước pháp quyền xã hội chủ nghĩa là hình thức thực hiện dân chủ; pháp luật vừa bảo đảm quyền làm chủ của nhân dân vừa điều chỉnh các quan hệ xã hội trong tiến trình xây dựng chủ nghĩa xã hội.
-
-## 2.3. So sánh cơ bản với dân chủ tư sản
-- **Cơ sở xã hội – giai cấp**: dân chủ tư sản mang bản chất giai cấp tư sản; dân chủ xã hội chủ nghĩa là dân chủ của đại đa số người lao động.
-- **Cơ chế chính trị**: dân chủ tư sản thường gắn với đa đảng, đa nguyên chính trị; dân chủ xã hội chủ nghĩa đề cao vai trò lãnh đạo duy nhất của Đảng như điều kiện thực hiện quyền làm chủ của nhân dân.
-- **Bản chất kinh tế**: dân chủ tư sản dựa trên sở hữu tư nhân; dân chủ xã hội chủ nghĩa dựa trên sở hữu xã hội các tư liệu sản xuất chủ yếu.
-- **Mục tiêu cuối cùng**: dân chủ tư sản hướng tới bảo vệ quyền tự do cá nhân trong khuôn khổ tư hữu; dân chủ xã hội chủ nghĩa hướng tới giải phóng đại đa số, bảo đảm công bằng xã hội và tiến tới xã hội không giai cấp.
-
-## 2.4. Điều kiện thực hiện, hạn chế và thách thức
-
-### 2.4.1. Điều kiện tiên quyết
-- Vai trò lãnh đạo của Đảng Cộng sản: Đảng phải gắn kết lý luận Mác – Lênin với thực tiễn, nâng cao năng lực lãnh đạo và khả năng tổ chức quần chúng.
-- Trình độ dân trí và xã hội công dân: cần nâng cao trình độ chính trị, pháp luật và năng lực tham gia quản lý xã hội để nhân dân thực sự làm chủ.
-- Cơ chế pháp luật bảo đảm: hệ thống pháp luật minh bạch, hiệu quả, bảo vệ quyền tự do cá nhân đồng thời bảo đảm lợi ích chung.
-- Điều kiện vật chất: phát triển lực lượng sản xuất, ổn định kinh tế là nền tảng để mở rộng dân chủ thực chất.
-
-### 2.4.2. Hạn chế thực tiễn
-- Xuất phát điểm kinh tế – xã hội thấp khiến mức độ dân chủ đạt được còn hạn chế.
-- Tác động ngoại cảnh (chiến tranh, can thiệp, cấm vận) làm suy yếu khả năng thực hiện dân chủ toàn diện.
-- Mâu thuẫn giữa yêu cầu duy trì vai trò lãnh đạo duy nhất của Đảng và mở rộng dân chủ trực tiếp đặt ra thách thức quản trị, đòi hỏi đổi mới thể chế để tăng minh bạch, trách nhiệm và sự tham gia xã hội.
-
-## 2.5. Hướng hoàn thiện và khuyến nghị
-- Nâng cao dân trí và năng lực xã hội công dân thông qua giáo dục chính trị – pháp luật, thúc đẩy văn hóa tham gia.
-- Hoàn thiện cơ chế pháp quyền bảo đảm minh bạch, trách nhiệm giải trình của bộ máy nhà nước; pháp luật phải bảo vệ quyền làm chủ của nhân dân.
-- Phát triển kinh tế – xã hội nhằm tạo nền tảng vật chất cho việc mở rộng dân chủ; cải thiện đời sống để nhân dân có điều kiện tham gia thực chất.
-- Đổi mới phương thức lãnh đạo của Đảng, tăng tính dân chủ trong nội bộ, tiếp thu ý kiến nhân dân và xây dựng cơ chế kiểm tra – giám sát nhằm hạn chế lạm quyền.
-- Xây dựng cơ chế tham gia rộng rãi từ cơ sở đến trung ương, khuyến khích các tổ chức quần chúng, hiệp hội nghề nghiệp và hình thức dân chủ trực tiếp phù hợp.
-
-## 2.6. Kết luận
-Dân chủ xã hội chủ nghĩa, theo triết học Mác – Lênin, là hình thái dân chủ cao hơn dân chủ tư sản vì hướng tới quyền làm chủ của đại đa số nhân dân lao động, gắn liền với sở hữu xã hội về tư liệu sản xuất và quản lý xã hội bằng nhà nước pháp quyền xã hội chủ nghĩa dưới sự lãnh đạo của Đảng Cộng sản. Quá trình xây dựng nền dân chủ này phụ thuộc vào điều kiện kinh tế, trình độ dân trí, thể chế pháp luật và bối cảnh quốc tế; tiếp tục hoàn thiện cơ chế pháp quyền, nâng cao năng lực tham gia của nhân dân và đổi mới phương thức lãnh đạo là những nhân tố then chốt để dân chủ xã hội chủ nghĩa trở nên sâu sắc, bền vững trong thực tiễn.
-`,
-            english: `
-# Socialist Democracy
-
-## 2.1. Description
-Democracy is simultaneously a historical category and a social value. Based on historical research and practical experience, Marxism–Leninism asserts that democracy is a product of class struggle and changes with each socio-economic formation. Within that trajectory, socialist democracy emerges as a qualitatively higher form than bourgeois democracy, aiming to ensure real mastery for the overwhelming majority of working people.
-
-### 2.1.1. Inheriting and Surpassing Earlier Democracies
-From a historical viewpoint, the founders of Marxism–Leninism emphasized that the struggle for democracy is a long, multi-stage process. Bourgeois democracy created many progressive values—freedom, equality, the rule of law—but because it rests on private ownership of the means of production, it remains “a democracy of the minority.” Marxism–Leninism therefore predicted and highlighted the inevitability of a new, qualitatively higher democracy: proletarian democracy, or socialist democracy.
-
-### 2.1.2. Practical Preconditions: From the Paris Commune to the October Revolution
-The idea of proletarian democracy germinated through class struggles, exemplified by the Paris Commune (1871). Only after the success of the October Revolution (1917) and the establishment of the Soviet state—the first socialist state—was socialist democracy institutionalized at the level of government. This milestone marked a qualitative leap in the history of democracy: power shifted from the minority to the real empowerment of the working majority.
-
-![From the Paris Commune to the October Revolution](/assets/blog-images/4.1.2-1.png)
-
-![Founding the first Soviet state](/assets/blog-images/4.1.2-2.png)
-
-### 2.1.3. Developmental Trajectory
-Marxist–Leninist philosophy stresses that socialist democracy develops from lower to higher levels, from incomplete to more complete forms, while selectively inheriting the positive values of previous democracies. Perfecting socialist democracy involves expanding people’s mastery, enhancing civic consciousness, and broadening participation in governance. When democracy is extended widely and deeply, the “political” character of the state—as an instrument of class rule—gradually fades, foreshadowing the eventual withering away of the state on the path to communist society.
-
-## 2.2. The Nature of Socialist Democracy
-Socialist democracy has a multi-dimensional nature encompassing politics, economics, ideology, culture, society, and the rule of law.
-
-### 2.2.1. Political Nature
-- Power belongs to the working people: socialist democracy serves the majority who were once exploited, rather than all classes on an ostensibly equal footing as in bourgeois society.
-- The leadership of the Communist Party: the single political leadership of a party representing the working class is decisive for ensuring that power truly belongs to the people. In Marxist–Leninist and Hồ Chí Minh thought, the Party rallies, enlightens, and organizes the masses to exercise mastery; thus socialist democracy is politically monistic but oriented toward the interests of the entire people.
-- Democratic centralism: combining centralization and democracy is the organizational principle that guarantees unity of action while creating space for popular participation.
-
-### 2.2.2. Economic Nature
-- Social ownership of the principal means of production: socialist democracy rests on social ownership, which secures the people’s real mastery over economic resources.
-- Distribution mainly according to labor: allocating benefits based on labor outcomes reduces injustice and steadily improves material living standards for all.
-- Historical process and material conditions: this economic nature fully unfolds only through political stability, productive development, and advances in productive forces.
-
-### 2.2.3. Ideological, Cultural, and Social Nature
-- Marxism–Leninism provides the guiding ideology while absorbing national cultural values and global progressive achievements.
-- Fostering well-rounded human development: democracy in the cultural–ideological realm facilitates intellectual growth, creativity, and personality development.
-- Harmonizing individual, collective, and societal interests through policies and social organization.
-
-### 2.2.4. Rule-of-Law Nature
-The socialist rule-of-law state is the vehicle for practicing democracy; law both guarantees popular mastery and regulates social relations throughout socialist construction.
-
-## 2.3. Fundamental Comparison with Bourgeois Democracy
-- **Social-class foundation:** bourgeois democracy bears the class nature of the bourgeoisie, whereas socialist democracy belongs to the working majority.
-- **Political mechanism:** bourgeois democracy typically features multi-party pluralism; socialist democracy affirms the Communist Party’s single leadership as the condition for popular mastery.
-- **Economic nature:** bourgeois democracy is grounded in private ownership; socialist democracy is founded on social ownership of the essential means of production.
-- **Ultimate goal:** bourgeois democracy safeguards individual freedoms within private property relations; socialist democracy strives to liberate the majority, secure social justice, and advance toward a classless society.
-
-## 2.4. Conditions, Limitations, and Challenges
-
-### 2.4.1. Prerequisites
-- Leadership of the Communist Party: the Party must link Marxism–Leninism with reality, improving leadership capacity and mass organization.
-- Civic literacy and civil society: raising political and legal awareness and building capacity for public participation are vital for genuine popular mastery.
-- Legal safeguards: a transparent, effective legal system protects individual freedoms while ensuring the common good.
-- Material conditions: developing productive forces and stabilizing the economy provide the material foundation for substantive democracy.
-
-### 2.4.2. Practical Limitations
-- Low socio-economic starting points in many socialist countries restrict the level of democracy achieved.
-- External pressures—wars, interventions, embargoes—undermine the ability to realize comprehensive democracy.
-- The tension between maintaining the Party’s singular leadership and expanding direct democracy poses governance challenges, demanding institutional renewal to enhance transparency, accountability, and social participation.
-
-## 2.5. Directions for Improvement and Practical Recommendations
-- Raise civic knowledge and capacity through political–legal education and by nurturing a culture of participation.
-- Perfect rule-of-law mechanisms to ensure transparency and accountability in state institutions; laws must truly protect the people’s mastery.
-- Promote socio-economic development to provide the material basis for expanding democracy and improving living standards so people can participate substantively.
-- Innovate the Party’s leadership methods by increasing internal democracy, absorbing public feedback, and strengthening oversight mechanisms to prevent abuse of power.
-- Build broad participation channels from grassroots to central levels, encouraging mass organizations, professional associations, and appropriate forms of direct democracy.
-
-## 2.6. Conclusion
-According to Marxist–Leninist philosophy, socialist democracy is a higher form of democracy than its bourgeois counterpart because it aims at the mastery of the working majority, rests on social ownership of the means of production, and governs society through a socialist rule-of-law state under Communist Party leadership. Building this democracy depends on economic conditions, civic literacy, legal institutions, and the international environment. Further perfecting rule-of-law mechanisms, enhancing public participation, and renewing leadership methods are decisive factors for deepening and sustaining socialist democracy in practice.
-`,
-        },
-        excerpt: {
-            vietnamese:
-                'Phân tích bản chất, điều kiện thực hiện và định hướng hoàn thiện dân chủ xã hội chủ nghĩa trên các phương diện chính trị, kinh tế và pháp quyền.',
-            english:
-                'Analyzes the nature, implementation conditions, and improvement directions of socialist democracy across political, economic, and legal dimensions.',
-        },
-        author: 'Admin',
-        date: '2024-05-15',
-        readTime: {
-            vietnamese: '25 phút',
-            english: '25 minutes',
-        },
-        image: '/assets/blog-images/4.1.2-thumbnail.png',
-        originalLanguage: 'vietnamese' as const,
-        quiz: {
-            vietnamese: [
-                {
-                    question: 'So với dân chủ tư sản, cơ sở kinh tế của dân chủ xã hội chủ nghĩa được nêu là gì?',
-                    options: [
-                        'Sở hữu tư nhân tư liệu sản xuất chủ yếu',
-                        'Sở hữu xã hội đối với tư liệu sản xuất chủ yếu',
-                        'Kinh tế tự cấp tự túc',
-                        'Tài chính do tư bản nước ngoài chi phối',
-                    ],
-                    correct: 1,
-                },
-                {
-                    question: 'Phát biểu nào đúng về mối quan hệ giữa dân chủ và pháp quyền trong dân chủ xã hội chủ nghĩa?',
-                    options: [
-                        'Pháp luật đối lập với dân chủ',
-                        'Pháp luật chỉ phục vụ bộ máy nhà nước',
-                        'Pháp luật vừa bảo đảm quyền làm chủ của nhân dân, vừa điều chỉnh các quan hệ xã hội',
-                        'Dân chủ càng cao thì càng không cần pháp luật',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'Mục tiêu cuối cùng của dân chủ xã hội chủ nghĩa là gì?',
-                    options: [
-                        'Bảo vệ tuyệt đối quyền tư hữu cá nhân',
-                        'Mở rộng thị trường tư bản',
-                        'Giải phóng đại đa số lao động, bảo đảm công bằng xã hội, hướng tới xã hội không giai cấp',
-                        'Tăng cường cạnh tranh đảng phái',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'Điều kiện tiên quyết để thực hiện dân chủ xã hội chủ nghĩa được nêu là gì?',
-                    options: [
-                        'Duy trì độc quyền tư hữu',
-                        'Vai trò lãnh đạo của Đảng Cộng sản gắn với nâng cao dân trí và cơ chế pháp luật bảo đảm',
-                        'Giảm sự tham gia của quần chúng',
-                        'Tách rời dân chủ khỏi phát triển kinh tế – xã hội',
-                    ],
-                    correct: 1,
-                },
-            ],
-            english: [
-                {
-                    question: 'Compared with bourgeois democracy, what is cited as the economic foundation of socialist democracy?',
-                    options: [
-                        'Private ownership of the principal means of production',
-                        'Social ownership of the principal means of production',
-                        'A self-sufficient subsistence economy',
-                        'Finances controlled by foreign capital',
-                    ],
-                    correct: 1,
-                },
-                {
-                    question: 'Which statement correctly describes the relationship between democracy and the rule of law in socialist democracy?',
-                    options: [
-                        'Law is opposed to democracy',
-                        'Law serves only the state apparatus',
-                        'Law both guarantees the people’s mastery and regulates social relations',
-                        'The higher the level of democracy, the less law is needed',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'What is the ultimate goal of socialist democracy?',
-                    options: [
-                        'Absolute protection of private ownership',
-                        'Expanding capitalist markets',
-                        'Liberating the working majority, ensuring social justice, and moving toward a classless society',
-                        'Intensifying party competition',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'What prerequisite is highlighted for realizing socialist democracy?',
-                    options: [
-                        'Maintaining monopoly private ownership',
-                        'The Communist Party’s leadership linked with raising civic literacy and ensuring legal safeguards',
-                        'Reducing popular participation',
-                        'Separating democracy from socio-economic development',
-                    ],
-                    correct: 1,
-                },
-            ],
-        },
-    },
-    3: {
-        id: 3,
-        section: '4.2' as SectionId,
-        title: {
-            vietnamese: 'Nhà nước xã hội chủ nghĩa',
-            english: 'The Socialist State',
-        },
-        content: {
-            vietnamese: `
-
-
-
-### 1. Mở đầu
-Trong lịch sử nhân loại, nhà nước là một hiện tượng xã hội – chính trị có tính tất yếu khách quan, gắn liền với sự phân hóa giai cấp. Tuy nhiên, các kiểu nhà nước bóc lột (chủ nô, phong kiến, tư sản) đều phản ánh quyền lực chính trị của thiểu số áp đặt lên đại đa số lao động. Chỉ đến khi cách mạng vô sản thắng lợi, nhà nước mới xuất hiện dưới một hình thức hoàn toàn mới – nhà nước xã hội chủ nghĩa. Đây là công cụ để giai cấp công nhân và nhân dân lao động tổ chức quản lý xã hội, xây dựng nền dân chủ mới, hướng tới xóa bỏ mọi hình thức áp bức, bất công và tiến tới xã hội cộng sản.
-
-### 2. Sự ra đời của nhà nước xã hội chủ nghĩa
-#### 2.1. Tiền đề lý luận và lịch sử
-Khát vọng về công bằng, bình đẳng và tự do vốn đã xuất hiện từ lâu trong lịch sử, nhưng chỉ đến khi chủ nghĩa tư bản phát triển, mâu thuẫn giữa lực lượng sản xuất mang tính xã hội hóa cao với quan hệ sản xuất dựa trên chế độ tư hữu ngày càng gay gắt thì giai cấp vô sản mới trở thành lực lượng xã hội có khả năng lãnh đạo cách mạng. Được trang bị vũ khí lý luận là chủ nghĩa Mác – Lênin, giai cấp công nhân thành lập Đảng Cộng sản để tổ chức và lãnh đạo phong trào cách mạng.
-
-#### 2.2. Kết quả của cách mạng vô sản
-Nhà nước xã hội chủ nghĩa ra đời là kết quả tất yếu của cuộc cách mạng do giai cấp vô sản và nhân dân lao động tiến hành dưới sự lãnh đạo của Đảng Cộng sản. Tùy vào điều kiện lịch sử, kinh tế, văn hóa và đặc điểm dân tộc, hình thức chính quyền sau cách mạng có thể khác nhau, nhưng bản chất chung là:
-
-- Tổ chức thực hiện quyền lực nhân dân;
-- Đại diện cho ý chí của nhân dân lao động;
-- Công cụ để quản lý kinh tế, văn hóa, xã hội;
-- Đặt dưới sự lãnh đạo của Đảng Cộng sản.
-
-![Sự ra đời của nhà nước xã hội chủ nghĩa](/assets/blog-images/4.2-1.png)
-
-### 3. Bản chất của nhà nước xã hội chủ nghĩa
-#### 3.1. Bản chất chính trị
-Nhà nước xã hội chủ nghĩa mang bản chất giai cấp công nhân – giai cấp có lợi ích thống nhất với lợi ích cơ bản của quần chúng lao động. Khác với sự thống trị chính trị của giai cấp bóc lột vốn là sự áp đặt của thiểu số lên đa số, sự thống trị của giai cấp công nhân là sự thống trị của đa số đối với thiểu số, nhằm giải phóng chính mình và toàn thể nhân loại bị áp bức. Vì vậy, nhà nước xã hội chủ nghĩa thực chất là nhà nước của nhân dân, do nhân dân, vì nhân dân.
-
-#### 3.2. Bản chất kinh tế
-Cơ sở kinh tế của nhà nước xã hội chủ nghĩa là chế độ công hữu về tư liệu sản xuất chủ yếu. Trên nền tảng đó, quan hệ sản xuất bóc lột bị thủ tiêu, lợi ích kinh tế của nhân dân được bảo đảm. Nhà nước không còn là công cụ thuần túy của giai cấp thống trị để đàn áp mà vừa thực hiện chức năng quản lý kinh tế – xã hội, vừa đóng vai trò “nửa nhà nước” trên con đường tiến tới tiêu vong.
-
-#### 3.3. Bản chất văn hóa – xã hội
-Nhà nước xã hội chủ nghĩa được xây dựng trên nền tảng lý luận của chủ nghĩa Mác – Lênin, đồng thời kế thừa giá trị văn hóa tiến bộ của nhân loại và bản sắc dân tộc. Nhà nước hướng tới thu hẹp dần khoảng cách giai cấp, bảo đảm công bằng xã hội, tạo điều kiện cho mọi công dân phát triển toàn diện.
-
-![Bản chất của nhà nước xã hội chủ nghĩa](/assets/blog-images/4.2-2.png)
-
-### 4. Chức năng của nhà nước xã hội chủ nghĩa
-#### 4.1. Theo phạm vi tác động
-- Đối nội: tổ chức quản lý xã hội, phát triển kinh tế, giữ gìn trật tự, bảo đảm an ninh chính trị, bảo vệ quyền và lợi ích nhân dân.
-- Đối ngoại: mở rộng quan hệ hợp tác, bảo vệ độc lập dân tộc, chống lại mọi sự xâm lược và can thiệp từ bên ngoài.
-
-#### 4.2. Theo lĩnh vực tác động
-- Chính trị: duy trì sự lãnh đạo của giai cấp công nhân thông qua Đảng Cộng sản, bảo vệ thành quả cách mạng.
-- Kinh tế: tổ chức sản xuất, phân phối, quản lý kinh tế quốc dân theo định hướng xã hội chủ nghĩa.
-- Văn hóa – xã hội: chăm lo đời sống vật chất và tinh thần của nhân dân, xây dựng nền văn hóa tiên tiến, đậm đà bản sắc dân tộc.
-
-#### 4.3. Theo tính chất quyền lực
-- Chức năng giai cấp (trấn áp): trấn áp giai cấp bóc lột đã bị lật đổ và các phần tử chống phá cách mạng.
-- Chức năng xã hội (xây dựng): quản lý và tổ chức xã hội, cải tạo xã hội cũ, xây dựng xã hội mới.
-
-> V.I. Lênin nhấn mạnh: “Nhà nước XHCN không phải chỉ là bạo lực đối với bọn bóc lột, mà cái quan trọng hơn là nó tạo ra năng suất lao động cao hơn chế độ cũ”.
-
-![Chức năng của nhà nước xã hội chủ nghĩa](/assets/blog-images/4.2-3.png)
-
-### 5. Mối quan hệ giữa dân chủ xã hội chủ nghĩa và nhà nước xã hội chủ nghĩa
-#### 5.1. Dân chủ xã hội chủ nghĩa là nền tảng của nhà nước xã hội chủ nghĩa
-Chỉ trong nền dân chủ xã hội chủ nghĩa, nhân dân mới có đủ điều kiện để thực hiện ý chí và quyền làm chủ của mình thông qua bầu cử, tham gia quản lý nhà nước và giám sát quyền lực. Nếu các nguyên tắc dân chủ xã hội chủ nghĩa bị vi phạm, nhà nước sẽ tha hóa thành công cụ của một nhóm người, đánh mất bản chất.
-
-#### 5.2. Nhà nước xã hội chủ nghĩa là công cụ hiện thực hóa dân chủ
-Nhà nước xã hội chủ nghĩa thể chế hóa ý chí nhân dân thành pháp luật, bảo đảm công bằng, phân định quyền và nghĩa vụ của công dân. Đồng thời, nhà nước là công cụ bạo lực để bảo vệ nền dân chủ, ngăn chặn mọi hành vi xâm phạm quyền lợi nhân dân. Theo Lênin, sự phát triển của nhà nước xã hội chủ nghĩa gắn liền với việc hoàn thiện hình thức dân chủ và mở rộng sự tham gia của nhân dân vào quản lý xã hội.
-
-![Mối quan hệ giữa dân chủ và nhà nước xã hội chủ nghĩa](/assets/blog-images/4.2-4.png)
-
-### 6. Kết luận
-Nhà nước xã hội chủ nghĩa là kiểu nhà nước mới, khác biệt về bản chất so với các nhà nước bóc lột trong lịch sử. Nó ra đời từ thắng lợi của cách mạng vô sản, mang bản chất giai cấp công nhân và đại biểu cho lợi ích của đại đa số nhân dân lao động. Nhà nước xã hội chủ nghĩa vừa thực hiện chức năng trấn áp thiểu số bóc lột, vừa quan trọng hơn là tổ chức quản lý, xây dựng xã hội mới. Mối quan hệ giữa dân chủ xã hội chủ nghĩa và nhà nước xã hội chủ nghĩa mang tính biện chứng: dân chủ là nền tảng, còn nhà nước là công cụ tổ chức, bảo vệ và hiện thực hóa dân chủ. Giữ vững bản chất, hoàn thiện chức năng và không ngừng mở rộng dân chủ là điều kiện quyết định để nhà nước xã hội chủ nghĩa phát huy vai trò trụ cột trong sự nghiệp xây dựng và bảo vệ Tổ quốc.
-`,
-            english: `
-
-
-
-### 1. Introduction
-Throughout human history, the state has been a socio-political phenomenon rooted in the objective necessity that accompanied class stratification. Yet every exploitative state—slave-owning, feudal, and bourgeois—expressed the political power of a minority imposed upon the laboring majority. Only when the proletarian revolution triumphed did the state emerge in an entirely new form: the socialist state. It is the instrument through which the working class and working people organize and manage society, build a new democracy, strive to abolish all oppression and injustice, and advance toward a communist society.
-
-### 2. The Emergence of the Socialist State
-#### 2.1. Theoretical and Historical Preconditions
-Yearnings for justice, equality, and freedom have existed throughout history, but only when capitalism matured—and the contradiction between highly socialized productive forces and private-property relations intensified—did the proletariat become a social force capable of leading revolution. Armed with the theoretical weapon of Marxism–Leninism, the working class founded the Communist Party to organize and guide the revolutionary movement.
-
-#### 2.2. Outcome of the Proletarian Revolution
-The socialist state emerges as the inevitable result of revolutions carried out by the proletariat and working people under the leadership of the Communist Party. Depending on historical, economic, cultural, and national conditions, the post-revolutionary form of government may differ, but its common essence is:
-
-- Organizing and exercising the people’s power;
-- Representing the will of the working masses;
-- Serving as the instrument for managing the economy, culture, and society;
-- Operating under the leadership of the Communist Party.
-
-![Emergence of the socialist state](/assets/blog-images/4.2-1.png)
-
-### 3. Essence of the Socialist State
-#### 3.1. Political Essence
-The socialist state bears the class nature of the working class, whose interests align with those of the laboring masses. Unlike exploitative rule—where a minority dominates the majority—the leadership of the working class represents the majority over the minority in order to liberate itself and all oppressed humanity. Consequently, the socialist state is genuinely a state of the people, by the people, and for the people.
-
-#### 3.2. Economic Essence
-Its economic foundation is public ownership of the principal means of production. On this basis, exploitative relations of production are abolished and the people’s economic interests are secured. The state is no longer merely an instrument of class repression; it both manages socio-economic life and functions as a “semi-state” on the path toward its eventual withering away.
-
-#### 3.3. Cultural and Social Essence
-The socialist state is built upon Marxism–Leninism while inheriting progressive human values and national cultural identity. It strives to narrow class divisions, ensure social justice, and create conditions for every citizen to develop comprehensively.
-
-![Essence of the socialist state](/assets/blog-images/4.2-2.png)
-
-### 4. Functions of the Socialist State
-#### 4.1. By Scope of Impact
-- Domestic: organize social management, develop the economy, maintain order, safeguard political security, and protect the people’s rights and interests.
-- External: expand cooperative relations, defend national independence, and resist aggression or interference from abroad.
-
-#### 4.2. By Fields of Activity
-- Political: uphold the leadership of the working class through the Communist Party and defend revolutionary achievements.
-- Economic: organize production, distribution, and national economic management along socialist lines.
-- Cultural and social: care for the material and spiritual life of the people and build an advanced culture imbued with national identity.
-
-#### 4.3. By Nature of Power
-- Class function (suppression): suppress the overthrown exploiting classes and counter-revolutionary elements.
-- Social function (construction): manage and organize society, transform the old order, and build the new one.
-
-> V.I. Lenin emphasized: “The socialist state is not only violence against the exploiters; what matters even more is that it creates a higher labor productivity than the old regime.”
-
-![Functions of the socialist state](/assets/blog-images/4.2-3.png)
-
-### 5. The Relationship Between Socialist Democracy and the Socialist State
-#### 5.1. Socialist Democracy as the Foundation of the Socialist State
-Only under socialist democracy do the people possess the conditions to realize their will and exercise mastery through elections, participation in state management, and oversight of power. If socialist-democratic principles are violated, the state degenerates into the tool of a clique and loses its essence.
-
-#### 5.2. The Socialist State as the Instrument for Realizing Democracy
-The socialist state institutionalizes the people’s will into law, ensures justice, and delineates citizens’ rights and obligations. At the same time, it wields coercive power to defend democracy and prevent violations of the people’s interests. Lenin argued that the development of the socialist state goes hand in hand with perfecting democratic forms and expanding popular participation in governance.
-
-![Relationship between socialist democracy and the socialist state](/assets/blog-images/4.2-4.png)
-
-### 6. Conclusion
-The socialist state is a new type of state whose essence differs from every exploitative state in history. Born from the triumph of the proletarian revolution, it embodies the working class and represents the interests of the laboring majority. The socialist state not only suppresses the remnants of exploiters but, more importantly, organizes and builds the new society. The relationship between socialist democracy and the socialist state is dialectical: democracy is the foundation, while the state is the instrument that organizes, protects, and realizes it. Preserving this essence, perfecting its functions, and constantly expanding democracy are decisive conditions for the socialist state to serve as a pillar in building and defending the nation.
-`,
-        },
-        excerpt: {
-            vietnamese:
-                'Tổng hợp toàn bộ nội dung chương 4.2 về nhà nước xã hội chủ nghĩa, từ tiền đề ra đời, bản chất, chức năng đến mối quan hệ với dân chủ xã hội chủ nghĩa.',
-            english:
-                'Comprehensive synthesis of Chapter 4.2 on the socialist state—from its origins and essence to its functions and relationship with socialist democracy.',
-        },
-        author: 'Admin',
-        date: '2024-05-20',
-        readTime: {
-            vietnamese: '40 phút',
-            english: '40 minutes',
-        },
-        image: '/assets/blog-images/4.2-thumbnail.png',
-        originalLanguage: 'vietnamese' as const,
-        quiz: {
-            vietnamese: [
-                {
-                    question:
-                        'Theo văn bản, điều gì làm nhà nước XHCN trở thành “hình thức hoàn toàn mới” so với các kiểu nhà nước bóc lột trước đó?',
-                    options: [
-                        'Duy trì chế độ tư hữu tư liệu sản xuất',
-                        'Quyền lực thuộc về thiểu số áp đặt lên đa số',
-                        'Công cụ của giai cấp công nhân và nhân dân lao động để tổ chức quản lý xã hội, xây dựng dân chủ mới',
-                        'Không cần đến bộ máy quyền lực',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'Tiền đề quyết định để giai cấp vô sản có khả năng lãnh đạo cách mạng là gì?',
-                    options: [
-                        'Sự suy yếu tất yếu của chế độ phong kiến',
-                        'Mâu thuẫn giữa lực lượng sản xuất mang tính xã hội hóa cao với quan hệ sản xuất dựa trên tư hữu',
-                        'Phong trào nông dân phát triển',
-                        'Sự ủng hộ của giai cấp tư sản dân tộc',
-                    ],
-                    correct: 1,
-                },
-                {
-                    question: 'Vai trò của Đảng Cộng sản trong sự ra đời nhà nước XHCN được nêu như thế nào?',
-                    options: [
-                        'Thay thế toàn bộ nhà nước hiện hữu',
-                        'Chỉ là công cụ đàn áp tạm thời',
-                        'Tổ chức và lãnh đạo phong trào cách mạng của giai cấp công nhân và nhân dân lao động',
-                        'Chỉ phụ trách đối ngoại',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'Bản chất chính trị của nhà nước XHCN là gì?',
-                    options: [
-                        'Sự thống trị của thiểu số đối với đa số',
-                        'Nhà nước trung lập về giai cấp',
-                        'Nhà nước của nhân dân, do nhân dân, vì nhân dân trên nền tảng giai cấp công nhân',
-                        'Nhà nước tư sản cải lương',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'Cơ sở kinh tế của nhà nước XHCN theo văn bản là gì?',
-                    options: [
-                        'Chế độ tư hữu tư liệu sản xuất',
-                        'Kinh tế tiểu nông phân tán',
-                        'Chế độ công hữu về tư liệu sản xuất chủ yếu',
-                        'Sở hữu cổ phần tư nhân là chủ đạo',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'Về bản chất văn hóa – xã hội, nhà nước XHCN hướng tới điều gì?',
-                    options: [
-                        'Duy trì khoảng cách giai cấp',
-                        'Phủ nhận toàn bộ giá trị văn hóa quá khứ',
-                        'Kế thừa giá trị tiến bộ của nhân loại và bản sắc dân tộc, bảo đảm công bằng, tạo điều kiện phát triển toàn diện cho công dân',
-                        'Chỉ chú trọng tăng trưởng kinh tế',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'Theo V.I. Lênin, điều gì “quan trọng hơn” đối với nhà nước XHCN?',
-                    options: [
-                        'Bạo lực đối với bọn bóc lột',
-                        'Tạo ra năng suất lao động cao hơn chế độ cũ',
-                        'Mở rộng tự do thương mại',
-                        'Xóa bỏ ngay lập tức mọi hình thức nhà nước',
-                    ],
-                    correct: 1,
-                },
-                {
-                    question: 'Hai mặt chức năng theo tính chất quyền lực của nhà nước XHCN là gì?',
-                    options: [
-                        'Đối nội và đối ngoại',
-                        'Kinh tế và văn hóa',
-                        'Giai cấp (trấn áp) và xã hội (xây dựng)',
-                        'Lập pháp và tư pháp',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'Chức năng đối nội của nhà nước XHCN KHÔNG bao gồm nội dung nào sau đây?',
-                    options: [
-                        'Tổ chức quản lý xã hội',
-                        'Bảo đảm an ninh chính trị',
-                        'Mở rộng quan hệ hợp tác quốc tế',
-                        'Bảo vệ quyền và lợi ích của nhân dân',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'Mối quan hệ giữa dân chủ XHCN và nhà nước XHCN được mô tả thế nào?',
-                    options: [
-                        'Dân chủ phụ thuộc hoàn toàn vào ý chí nhà nước',
-                        'Dân chủ là nền tảng, nhà nước là công cụ hiện thực hóa và bảo vệ dân chủ',
-                        'Dân chủ và nhà nước tách rời, không liên quan',
-                        'Hai yếu tố mâu thuẫn đối kháng',
-                    ],
-                    correct: 1,
-                },
-            ],
-            english: [
-                {
-                    question:
-                        'According to the text, what makes the socialist state a “completely new form” compared with earlier exploitative states?',
-                    options: [
-                        'Maintaining private ownership of the means of production',
-                        'Power remaining in the hands of a minority over the majority',
-                        'Serving as the instrument of the working class and laboring people to organize society and build a new democracy',
-                        'Dispensing with any apparatus of power',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'What decisive precondition enables the proletariat to lead the revolution?',
-                    options: [
-                        'The inevitable weakening of feudalism',
-                        'The contradiction between highly socialized productive forces and private-property relations',
-                        'The expansion of peasant uprisings',
-                        'Support from the national bourgeoisie',
-                    ],
-                    correct: 1,
-                },
-                {
-                    question: 'How is the Communist Party’s role in the emergence of the socialist state described?',
-                    options: [
-                        'Replacing the entire existing state apparatus',
-                        'Acting only as a temporary tool of repression',
-                        'Organizing and leading the revolutionary movement of the working class and working people',
-                        'Handling foreign affairs exclusively',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'What is identified as the political essence of the socialist state?',
-                    options: [
-                        'Minority domination over the majority',
-                        'A class-neutral state',
-                        'A state of the people, by the people, and for the people grounded in the working class',
-                        'A reformed bourgeois state',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'According to the text, what forms the economic foundation of the socialist state?',
-                    options: [
-                        'Private ownership of the means of production',
-                        'A dispersed smallholder economy',
-                        'Public ownership of the principal means of production',
-                        'Private shareholding as the dominant form',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'Regarding cultural and social essence, what does the socialist state aim to achieve?',
-                    options: [
-                        'Maintaining class divisions',
-                        'Rejecting all past cultural values',
-                        'Inheriting progressive human and national values, ensuring justice, and enabling citizens’ all-round development',
-                        'Focusing solely on economic growth',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'According to V.I. Lenin, what is “more important” for the socialist state?',
-                    options: [
-                        'Violence against the exploiters',
-                        'Achieving higher labor productivity than the old regime',
-                        'Expanding free trade',
-                        'Abolishing every form of state immediately',
-                    ],
-                    correct: 1,
-                },
-                {
-                    question: 'What are the two facets of the socialist state’s functions by the nature of power?',
-                    options: [
-                        'Domestic and foreign',
-                        'Economic and cultural',
-                        'Class (suppression) and social (construction)',
-                        'Legislative and judicial',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'Which activity is NOT part of the socialist state’s domestic function?',
-                    options: [
-                        'Organizing social management',
-                        'Ensuring political security',
-                        'Expanding international cooperation',
-                        'Protecting the people’s rights and interests',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'How is the relationship between socialist democracy and the socialist state described?',
-                    options: [
-                        'Democracy depends entirely on the state’s will',
-                        'Democracy is the foundation, while the state is the instrument that realizes and safeguards it',
-                        'Democracy and the state are separate and unrelated',
-                        'The two elements are antagonistic',
-                    ],
-                    correct: 1,
-                },
-            ],
-        },
-    },
-    9: {
-        id: 9,
-        section: '4.3.1' as SectionId,
-        title: {
-            vietnamese: 'Dân chủ xã hội chủ nghĩa ở Việt Nam',
-            english: 'Socialist Democracy in Vietnam',
-        },
-        content: {
-            vietnamese: `
-
-
-## III. Dân chủ xã hội chủ nghĩa và Nhà nước pháp quyền xã hội chủ nghĩa ở Việt Nam
-
-### 1. Dân chủ xã hội chủ nghĩa ở Việt Nam
-
-#### 1.1. Sự ra đời, phát triển của nền dân chủ xã hội chủ nghĩa ở Việt Nam
-Chế độ dân chủ nhân dân ở nước ta được xác lập sau Cách mạng Tháng Tám năm 1945. Đến năm 1976, tên nước được đổi thành **Cộng hòa xã hội chủ nghĩa Việt Nam**, nhưng trong các văn kiện Đảng lúc bấy giờ, cụm từ “dân chủ xã hội chủ nghĩa” chưa được sử dụng phổ biến mà thường đề cập nhiệm vụ “xây dựng chế độ làm chủ tập thể xã hội chủ nghĩa” gắn với yêu cầu “nắm vững chuyên chính vô sản”.
-
-Bản chất dân chủ xã hội chủ nghĩa, cũng như mối quan hệ giữa dân chủ xã hội chủ nghĩa và nhà nước pháp quyền xã hội chủ nghĩa, vẫn chưa được nhận thức thật rõ. Việc thực hiện dân chủ trong thời kỳ quá độ lên chủ nghĩa xã hội – sao cho phù hợp với điều kiện kinh tế, xã hội, văn hóa, đạo đức của Việt Nam và gắn với việc hoàn thiện hệ thống pháp luật, kỷ cương – chưa được xác định một cách cụ thể.
-
-Nhiều lĩnh vực gắn bó mật thiết với dân chủ xã hội chủ nghĩa như dân sinh, dân trí, dân quyền chưa được đặt đúng vị trí, khiến nền dân chủ xã hội chủ nghĩa chưa phát huy được toàn diện.
-
-Đại hội VI của Đảng (1986) đã khởi xướng đường lối đổi mới toàn diện, nhấn mạnh phát huy dân chủ để tạo động lực mạnh mẽ cho phát triển đất nước. Đại hội khẳng định: “Trong toàn bộ hoạt động của mình, Đảng phải quán triệt tư tưởng lấy dân làm gốc, xây dựng và phát huy quyền làm chủ của nhân dân lao động”; bài học “cách mạng là sự nghiệp của quần chúng” luôn giữ vai trò then chốt. Thực tiễn chứng minh: nơi nào nhân dân có ý thức làm chủ và được làm chủ thực sự, nơi đó phong trào cách mạng phát triển.
-
-Sau hơn 30 năm đổi mới, nhận thức về dân chủ xã hội chủ nghĩa ở nước ta đã có bước tiến quan trọng. Qua mỗi kỳ đại hội, dân chủ ngày càng được hiểu đúng và vận dụng phù hợp với điều kiện cụ thể của Việt Nam. Đảng xác định một trong những đặc trưng của chủ nghĩa xã hội Việt Nam là **do nhân dân làm chủ**, đưa dân chủ vào mục tiêu tổng quát “dân giàu, nước mạnh, dân chủ, công bằng, văn minh”. Đồng thời, Đảng khẳng định: “Dân chủ xã hội chủ nghĩa là bản chất của chế độ ta, vừa là mục tiêu, vừa là động lực phát triển đất nước. Xây dựng và từng bước hoàn thiện nền dân chủ xã hội chủ nghĩa, bảo đảm dân chủ được thực hiện trong thực tế cuộc sống ở mỗi cấp, trên tất cả các lĩnh vực. Dân chủ gắn liền với kỷ luật, kỷ cương và phải được thể chế hóa bằng pháp luật, được pháp luật bảo đảm…”.
-
-
-
-#### 1.2. Bản chất của nền dân chủ xã hội chủ nghĩa ở Việt Nam
-Cũng như nền dân chủ xã hội chủ nghĩa nói chung, bản chất dân chủ ở Việt Nam dựa trên **Nhà nước xã hội chủ nghĩa** và sự ủng hộ, tham gia của nhân dân. Đây là nền dân chủ lấy con người làm trung tâm trong tư cách công dân – chủ thể làm chủ xã hội, với quyền lực thuộc trọn vẹn về nhân dân.
-
-Hồ Chí Minh khẳng định: “Nước ta là nước dân chủ. Bao nhiêu lợi ích đều vì dân. Bao nhiêu quyền hạn đều là của dân… Nói tóm lại, quyền hành và lực lượng đều ở dân”. Đảng kế thừa tư tưởng ấy, xác định xây dựng nền dân chủ xã hội chủ nghĩa vừa là mục tiêu, vừa là động lực phát triển, đồng thời là bản chất của chế độ.
-
-Dân chủ phải gắn với kỷ luật, kỷ cương và được thể chế hóa bằng pháp luật. Nội dung này bao hàm:
-
-- **Dân chủ là mục tiêu** của chế độ xã hội chủ nghĩa (dân giàu, nước mạnh, dân chủ, công bằng, văn minh).
-- **Dân chủ là bản chất** của chế độ xã hội chủ nghĩa (do nhân dân làm chủ, quyền lực thuộc về nhân dân).
-- **Dân chủ là động lực** xây dựng chủ nghĩa xã hội (phát huy sức mạnh của nhân dân, của toàn dân tộc).
-- **Dân chủ gắn với pháp luật**, với kỷ luật, kỷ cương xã hội.
-- **Dân chủ phải được thực hiện** trên mọi lĩnh vực đời sống: kinh tế, chính trị, văn hóa, xã hội.
-
-Bản chất dân chủ xã hội chủ nghĩa được triển khai qua hai hình thức:
-
-- **Dân chủ gián tiếp (đại diện)**: Nhân dân ủy quyền cho các cơ quan do mình bầu ra. Quốc hội – cơ quan quyền lực cao nhất – hoạt động theo nhiệm kỳ 5 năm; quyền lực nhà nước thống nhất, có phân công, phối hợp và kiểm soát giữa lập pháp, hành pháp, tư pháp.
-- **Dân chủ trực tiếp**: Nhân dân trực tiếp thực hiện quyền làm chủ thông qua quyền được thông tin, bàn bạc, quyết định các vấn đề quan trọng ở cơ sở và giám sát hoạt động của bộ máy nhà nước từ Trung ương đến địa phương.
-
-Trong thực tiễn đổi mới, nền dân chủ xã hội chủ nghĩa ở Việt Nam không ngừng mở rộng:
-
-- Quyền làm chủ của nhân dân được bảo đảm và phát huy hiệu quả.
-- Ý thức công dân và trách nhiệm xã hội ngày càng được đề cao trong pháp luật và đời sống.
-- Mọi công dân có điều kiện tham gia quản lý xã hội tùy theo vị trí và nghĩa vụ của mình.
-- Dân chủ gắn với kỷ cương, được thể chế hóa bằng pháp luật của nhà nước pháp quyền.
-- Quy chế dân chủ từ cơ sở đến Trung ương và trong các tổ chức chính trị – xã hội đều thực hiện phương châm “dân biết, dân bàn, dân làm, dân kiểm tra”.
-
-Đảng khẳng định: “Mọi đường lối, chính sách của Đảng và pháp luật của Nhà nước đều vì lợi ích của nhân dân, có sự tham gia ý kiến của nhân dân”.
-
-Tuy nhiên, việc xây dựng dân chủ xã hội chủ nghĩa còn đối mặt với nhiều khó khăn: xuất phát điểm kinh tế thấp, hậu quả chiến tranh, tiêu cực xã hội, âm mưu “diễn biến hòa bình”, nguy cơ “tự diễn biến, tự chuyển hóa”. Dẫu vậy, bản chất ưu việt của nền dân chủ xã hội chủ nghĩa ngày càng thể hiện rõ giá trị “lấy dân làm gốc”: nhân dân trở thành chủ thể xây dựng, tổ chức và quản lý xã hội; quyền làm chủ được bảo đảm trên tất cả các lĩnh vực và khơi dậy sức sáng tạo trong sự nghiệp xây dựng, bảo vệ Tổ quốc xã hội chủ nghĩa.
-`,
-            english: `
-
-
-## III. Socialist Democracy and the Socialist Rule-of-Law State in Vietnam
-
-### 1. Socialist Democracy in Vietnam
-
-#### 1.1. Emergence and Development
-People’s democracy in Vietnam was established after the August Revolution of 1945. When the nation adopted the name **Socialist Republic of Vietnam** in 1976, Party documents still seldom used the term “socialist democracy,” instead emphasizing the task of “building the socialist collective mastery regime” alongside “maintaining the proletarian dictatorship.”
-
-At that time the nature of socialist democracy and its relationship with the socialist rule-of-law state remained insufficiently defined. How to exercise democracy during the transition to socialism—tailored to Vietnam’s socio-economic, cultural, and ethical features and tied to strengthening the legal system and public discipline—was still an open question.
-
-Many areas closely linked to socialist democracy, such as livelihoods, education, and civic rights, had not been given proper priority, limiting democratic development.
-
-The Party’s 6th National Congress in 1986 launched comprehensive renovation, stressing democracy as a powerful driver of national progress. It affirmed: “In all its activities, the Party must thoroughly grasp the idea that the people are the root, and must build and promote the working people’s mastery”; the lesson that “revolution is the cause of the masses” remains fundamental. Practice proves that where people are conscious of their role and truly exercise mastery, revolutionary movements flourish.
-
-More than three decades of renovation have deepened Vietnam’s understanding of socialist democracy. Each Party congress has refined democratic thinking to suit the country’s realities. The Party identifies people’s mastery as a defining feature of Vietnamese socialism, embedding democracy in the overarching goal of “a prosperous people, a strong nation, democracy, justice, and civilization.” It also states: “Socialist democracy is the essence of our regime, both the goal and the driving force of national development. We must build and gradually perfect socialist democracy, ensuring it is practiced in real life at every level and across all fields. Democracy must be linked with discipline and order, institutionalized by law, and guaranteed by law….”
-
-
-
-#### 1.2. Nature of Socialist Democracy in Vietnam
-Like socialist democracy in general, Vietnam’s democracy rests on the **socialist state** and the people’s support and participation. It places citizens at the center as masters of society, with power belonging entirely to the people.
-
-Hồ Chí Minh declared: “Our country is democratic. All benefits are for the people. All power belongs to the people… In short, authority and strength are in the people.” The Party inherits that thought, viewing socialist democracy as both goal and driving force and as the very essence of the socialist regime.
-
-Democracy must be tied to discipline and order and institutionalized in law. This includes:
-
-- **Democracy as the goal** of socialism (a prosperous people, a strong nation, democracy, justice, civilization).
-- **Democracy as the essence** of the socialist regime (power belongs to the people).
-- **Democracy as the driving force** for building socialism (mobilizing the strength of the entire nation).
-- **Democracy linked with law**, discipline, and social order.
-- **Democracy practiced** across all spheres: economics, politics, culture, and society.
-
-This democratic nature is expressed in two forms:
-
-- **Indirect (representative) democracy:** the people entrust power to institutions they elect. The National Assembly—the highest organ of state power—serves five-year terms; state power is unified yet divided, coordinated, and supervised among the legislative, executive, and judicial bodies.
-- **Direct democracy:** citizens exercise mastery by accessing information, deliberating on public affairs, deciding key grassroots matters, and overseeing state agencies from central to local levels.
-
-In practice, Vietnam’s socialist democracy has continually expanded:
-
-- The people’s mastery is secured and effectively promoted.
-- Civic awareness and social responsibility are increasingly emphasized in law and daily life.
-- Citizens have opportunities to participate in governance appropriate to their roles and obligations.
-- Democracy is coupled with discipline and institutionalized by the socialist rule-of-law state.
-- Democratic regulations from grassroots to central levels and within socio-political organizations follow the motto “people know, people discuss, people do, people supervise.”
-
-The Party affirms: “All Party lines and State policies and laws serve the people’s interests and include people’s opinions.”
-
-Nevertheless, building socialist democracy still faces challenges: low economic starting points, war legacies, social problems, hostile schemes of “peaceful evolution,” and the risks of “self-evolution” and “self-transformation.” Even so, the superior nature of socialist democracy increasingly shines through the principle of “the people as the root,” enabling citizens to build, organize, and manage society, ensure their rights in all fields, and unleash creativity in building and defending the socialist Fatherland.
-`,
-        },
-        excerpt: {
-            vietnamese:
-                'Trình bày tiến trình hình thành, bản chất và hình thức thực hiện dân chủ xã hội chủ nghĩa ở Việt Nam thời kỳ đổi mới.',
-            english:
-                'Outlines the emergence, nature, and implementation of socialist democracy in Vietnam during the renovation era.',
-        },
-        author: 'Admin',
-        date: '2024-05-25',
-        readTime: {
-            vietnamese: '28 phút',
-            english: '28 minutes',
-        },
-        image: '/assets/blog-images/4.3.1-thumbnail.png',
-        originalLanguage: 'vietnamese' as const,
-        quiz: {
-            vietnamese: [
-                {
-                    question: 'Chế độ dân chủ nhân dân ở Việt Nam được xác lập vào thời điểm nào?',
-                    options: [
-                        'Sau Hiệp định Genève năm 1954',
-                        'Sau Cách mạng Tháng Tám năm 1945',
-                        'Sau Đại hội VI năm 1986',
-                        'Sau khi thống nhất đất nước năm 1975',
-                    ],
-                    correct: 1,
-                },
-                {
-                    question: 'Đại hội VI (1986) nêu vai trò của dân chủ như thế nào trong đổi mới?',
-                    options: [
-                        'Dân chủ chỉ là mục tiêu xa',
-                        'Dân chủ là thủ tục hành chính',
-                        'Phát huy dân chủ là một động lực mạnh mẽ cho phát triển',
-                        'Dân chủ chỉ áp dụng ở cấp cơ sở',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'Quan điểm của Đảng về dân chủ xã hội chủ nghĩa thời kỳ đổi mới là gì?',
-                    options: [
-                        'Chỉ là mục tiêu, không phải động lực',
-                        'Là bản chất của chế độ, vừa là mục tiêu, vừa là động lực; gắn với kỷ luật, kỷ cương và phải được thể chế hóa bằng pháp luật',
-                        'Chỉ cần thực hiện bằng phong trào',
-                        'Không cần đưa vào mục tiêu tổng quát',
-                    ],
-                    correct: 1,
-                },
-                {
-                    question: 'Ví dụ nào sau đây là biểu hiện của dân chủ trực tiếp?',
-                    options: [
-                        'Nhân dân bầu đại biểu Quốc hội theo nhiệm kỳ',
-                        'Nhân dân ủy quyền cho tổ chức đại diện thực hiện quyền lực',
-                        'Nhân dân kiểm tra, giám sát hoạt động của cơ quan nhà nước',
-                        'Quốc hội thực hiện quyền lập pháp',
-                    ],
-                    correct: 2,
-                },
-            ],
-            english: [
-                {
-                    question: 'When was people’s democracy established in Vietnam?',
-                    options: [
-                        'After the 1954 Geneva Accords',
-                        'After the August Revolution of 1945',
-                        'After the 6th Party Congress in 1986',
-                        'After national reunification in 1975',
-                    ],
-                    correct: 1,
-                },
-                {
-                    question: 'How did the 6th Party Congress (1986) highlight the role of democracy in renovation?',
-                    options: [
-                        'Democracy is only a distant goal',
-                        'Democracy is merely an administrative procedure',
-                        'Promoting democracy is a powerful driving force for development',
-                        'Democracy applies only at the grassroots level',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'What is the Party’s view of socialist democracy in the renovation period?',
-                    options: [
-                        'It is only a goal, not a driving force',
-                        'It is the regime’s essence—both goal and driver—linked to discipline and codified in law',
-                        'It only needs to be carried out as a movement',
-                        'It need not be part of the overarching goals',
-                    ],
-                    correct: 1,
-                },
-                {
-                    question: 'Which example illustrates direct democracy in Vietnam’s context?',
-                    options: [
-                        'The people elect National Assembly deputies for fixed terms',
-                        'Citizens delegate their power to representative institutions',
-                        'The people inspect and supervise state agencies’ activities',
-                        'The National Assembly exercises legislative power',
-                    ],
-                    correct: 2,
-                },
-            ],
-        },
-    },
-    10: {
-        id: 10,
-        section: '4.3.2' as SectionId,
-        title: {
-            vietnamese: 'Nhà nước pháp quyền xã hội chủ nghĩa ở Việt Nam',
-            english: 'The Socialist Rule-of-Law State in Vietnam',
-        },
-        content: {
-            vietnamese: `
-
-
-## III. Dân chủ xã hội chủ nghĩa và Nhà nước pháp quyền xã hội chủ nghĩa ở Việt Nam
-
-### 2. Nhà nước pháp quyền xã hội chủ nghĩa ở Việt Nam
-
-#### 2.1. Quan niệm về nhà nước pháp quyền xã hội chủ nghĩa ở Việt Nam
-Theo quan niệm chung, nhà nước pháp quyền là nhà nước thượng tôn pháp luật, chú trọng phúc lợi cho mọi người và tạo điều kiện để cá nhân tự do, bình đẳng phát huy năng lực. Bộ máy nhà nước vận hành trên nguyên tắc phân công, kiểm soát quyền lực và được xã hội chấp nhận.
-
-Trong bối cảnh hiện nay, vẫn có nhiều cách tiếp cận khác nhau về nhà nước pháp quyền. Tuy vậy, điểm thống nhất là: mọi công dân phải được giáo dục và tuân thủ pháp luật; pháp luật phải nghiêm minh; các cơ quan nhà nước phải kiểm soát lẫn nhau, hoạt động vì mục tiêu phục vụ nhân dân.
-
-Cương lĩnh xây dựng đất nước trong thời kỳ quá độ lên chủ nghĩa xã hội của Đảng Cộng sản Việt Nam nêu rõ các định hướng: đề cao vai trò tối thượng của Hiến pháp và pháp luật; bảo đảm quyền, nghĩa vụ công dân và quyền con người; tổ chức bộ máy vừa tập trung, thống nhất vừa phân công, phân cấp giữa các cấp chính quyền để tránh lạm quyền; duy trì mối quan hệ chặt chẽ giữa Nhà nước với nhân dân, chịu sự giám sát của nhân dân; thiết lập cơ chế kiểm soát, phòng ngừa tham nhũng, lộng quyền.
-
-Theo tiến trình đổi mới, nhận thức của Đảng về nhà nước pháp quyền ngày càng sáng tỏ. Chủ trương “xây dựng Nhà nước pháp quyền Việt Nam của dân, do dân, vì dân” nhấn mạnh Nhà nước quản lý xã hội bằng pháp luật; mọi cơ quan, tổ chức, cán bộ, công chức và công dân đều phải chấp hành Hiến pháp, pháp luật. Đại hội XII của Đảng khẳng định: “Quyền lực nhà nước là thống nhất, có sự phân công, phối hợp, kiểm soát giữa các cơ quan nhà nước trong việc thực hiện các quyền lập pháp, hành pháp, tư pháp”.
-
-#### 2.2. Đặc điểm của nhà nước pháp quyền xã hội chủ nghĩa ở Việt Nam
-Từ thực tiễn xây dựng trong thời kỳ đổi mới, nhà nước pháp quyền xã hội chủ nghĩa ở Việt Nam có những đặc điểm cơ bản:
-
-1. **Nhà nước của dân, do dân, vì dân**, bảo đảm quyền làm chủ của nhân dân lao động.
-2. **Tổ chức và hoạt động trên cơ sở Hiến pháp, pháp luật** – pháp luật giữ vị trí tối thượng trong điều chỉnh các quan hệ xã hội.
-3. **Quyền lực nhà nước thống nhất**, có phân công rõ ràng, phối hợp nhịp nhàng và kiểm soát giữa lập pháp, hành pháp, tư pháp.
-4. **Đặt dưới sự lãnh đạo của Đảng Cộng sản Việt Nam**, phù hợp điều 4 Hiến pháp 2013; hoạt động của Nhà nước chịu sự giám sát của nhân dân theo phương châm “dân biết, dân bàn, dân làm, dân kiểm tra”.
-5. **Tôn trọng quyền con người**, xem con người là chủ thể và trung tâm phát triển; nhân dân có quyền bầu, bãi miễn đại biểu không xứng đáng; pháp luật được thực thi nghiêm minh.
-6. **Tổ chức bộ máy theo nguyên tắc tập trung dân chủ**, có phân công, phân cấp, phối hợp và kiểm soát lẫn nhau, bảo đảm sự chỉ đạo thống nhất của Trung ương.
-
-
-Những đặc điểm này thể hiện đầy đủ tinh thần chung của nhà nước pháp quyền, đồng thời nhấn mạnh bản sắc của nhà nước pháp quyền xã hội chủ nghĩa Việt Nam: mang bản chất giai cấp công nhân, phục vụ nhân dân và là công cụ để Đảng lãnh đạo sự nghiệp xây dựng chủ nghĩa xã hội.
-`,
-            english: `
-
-
-## III. Socialist Democracy and the Socialist Rule-of-Law State in Vietnam
-
-### 2. Vietnam’s Socialist Rule-of-Law State
-
-#### 2.1. Conceptual Foundations
-A rule-of-law state upholds the supremacy of law, prioritizes public welfare, and creates conditions for individuals to enjoy freedom, equality, and personal development. State institutions operate on the basis of delegated and mutually controlled powers accepted by society.
-
-Although contemporary approaches vary, they converge on several essentials: citizens must be educated about and comply with the law; the law must be stringent; and state bodies must check and balance one another in service of the people.
-
-The Communist Party of Vietnam’s Platform for national construction in the transition to socialism sets key directions: highlight the paramount role of the Constitution and laws; guarantee citizens’ rights and human rights; build an apparatus that remains centralized and unified while dividing and delegating authority across levels to prevent abuse of power; maintain close ties with the people under their supervision; and create mechanisms to prevent and sanction bureaucracy and corruption.
-
-As renovation progressed, the Party’s understanding of the rule-of-law state sharpened. The guideline of “building a socialist rule-of-law State of the people, by the people, for the people” emphasizes governing society by law; all agencies, organizations, cadres, civil servants, and citizens must observe the Constitution and the law. The 12th Party Congress affirmed: “State power is unified, with a division, coordination, and control among state agencies in exercising legislative, executive, and judicial powers.”
-
-#### 2.2. Key Characteristics
-Experience from the renovation era reveals several core traits of Vietnam’s socialist rule-of-law state:
-
-1. **A state of the people, by the people, for the people**, ensuring the working people’s mastery.
-2. **Organization and operation grounded in the Constitution and laws**, which hold supreme authority in regulating social relations.
-3. **Unified state power** with clear functional division, harmonious coordination, and mutual oversight among the legislature, executive, and judiciary.
-4. **Leadership of the Communist Party of Vietnam**, consistent with Article 4 of the 2013 Constitution; state activity is overseen by the populace under the motto “people know, people discuss, people do, people supervise.”
-5. **Respect for human rights**, placing human beings at the center of development; citizens can elect and recall unworthy representatives while the law is rigorously enforced.
-6. **Organization based on democratic centralism**, incorporating division, decentralization, coordination, and mutual control while safeguarding the unified leadership of the central government.
-
-
-
-These features embody the universal spirit of the rule-of-law state while underlining Vietnam’s specificity: a socialist rule-of-law state that carries the working-class nature, serves the people, and functions as the primary instrument for the Communist Party to steer the path toward socialism.
-`,
-        },
-        excerpt: {
-            vietnamese:
-                'Làm rõ quan niệm và đặc điểm của Nhà nước pháp quyền xã hội chủ nghĩa Việt Nam trong tiến trình đổi mới.',
-            english:
-                'Explains the concept and defining traits of Vietnam’s socialist rule-of-law state throughout the renovation period.',
-        },
-        author: 'Admin',
-        date: '2024-05-25',
-        readTime: {
-            vietnamese: '20 phút',
-            english: '20 minutes',
-        },
-        image: '/assets/blog-images/4.3.2-thumbnail.png',
-        originalLanguage: 'vietnamese' as const,
-        quiz: {
-            vietnamese: [
-                {
-                    question: 'Trong các đặc điểm sau, đâu là điểm KHÔNG thuộc Nhà nước pháp quyền XHCN ở Việt Nam?',
-                    options: [
-                        'Quyền lực nhà nước thống nhất, có phân công, phối hợp, kiểm soát giữa lập pháp – hành pháp – tư pháp',
-                        'Tổ chức và hoạt động dựa trên Hiến pháp và pháp luật ở vị trí tối thượng',
-                        'Do Đảng Cộng sản Việt Nam lãnh đạo theo Hiến pháp 2013',
-                        '“Tam quyền phân lập” tuyệt đối, tách rời không phối hợp',
-                    ],
-                    correct: 3,
-                },
-                {
-                    question: 'Nội dung “dân biết, dân bàn, dân làm, dân kiểm tra” gắn với ý nào sau đây?',
-                    options: [
-                        'Cơ chế thực hiện dân chủ ở cơ sở và giám sát của nhân dân',
-                        'Quy trình lập pháp của Quốc hội',
-                        'Cải cách tư pháp',
-                        'Phân cấp ngân sách nhà nước',
-                    ],
-                    correct: 0,
-                },
-            ],
-            english: [
-                {
-                    question: 'Which of the following is NOT a feature of Vietnam’s socialist rule-of-law state?',
-                    options: [
-                        'Unified state power with division, coordination, and oversight among the legislative, executive, and judicial branches',
-                        'Organization and operation based on the supremacy of the Constitution and laws',
-                        'Leadership by the Communist Party of Vietnam as stipulated in the 2013 Constitution',
-                        'Absolute separation of powers with no coordination among branches',
-                    ],
-                    correct: 3,
-                },
-                {
-                    question: 'The motto “people know, people discuss, people do, people supervise” is associated with which mechanism?',
-                    options: [
-                        'Implementing grassroots democracy and public oversight',
-                        'The National Assembly’s legislative procedure',
-                        'Judicial reform',
-                        'Fiscal decentralization',
-                    ],
-                    correct: 0,
-                },
-            ],
-        },
-    },
-    11: {
-        id: 11,
-        section: '4.3.3' as SectionId,
-        title: {
-            vietnamese: 'Phát huy dân chủ, xây dựng Nhà nước pháp quyền XHCN hiện nay',
-            english: 'Promoting Democracy & Building Today’s Socialist Rule-of-Law State',
-        },
-        content: {
-            vietnamese: `
-
-
-## III. Dân chủ xã hội chủ nghĩa và Nhà nước pháp quyền xã hội chủ nghĩa ở Việt Nam
-
-### 3. Phát huy dân chủ xã hội chủ nghĩa, xây dựng Nhà nước pháp quyền xã hội chủ nghĩa ở Việt Nam hiện nay
-
-#### 3.1. Phát huy dân chủ xã hội chủ nghĩa ở Việt Nam hiện nay
-1. **Xây dựng, hoàn thiện thể chế kinh tế thị trường định hướng xã hội chủ nghĩa** nhằm tạo nền tảng kinh tế vững chắc cho dân chủ xã hội chủ nghĩa. Điều này bao gồm thể chế hóa quan điểm phát triển đa dạng sở hữu, thành phần kinh tế; bảo hộ quyền lợi hợp pháp của các chủ sở hữu; xây dựng luật pháp về các loại tài sản mới; hoàn thiện thể chế đồng bộ từ khâu ban hành, vận hành đến giám sát. Song song là cải cách mạnh mẽ thủ tục hành chính, phát triển đồng bộ các yếu tố thị trường và hoàn thiện khung pháp lý về kinh doanh.
-
-2. **Xây dựng Đảng Cộng sản Việt Nam trong sạch, vững mạnh** – điều kiện tiên quyết của dân chủ xã hội chủ nghĩa. Đảng phải vững về chính trị, tư tưởng, tổ chức; thường xuyên tự đổi mới, tự chỉnh đốn; nâng cao trí tuệ, bản lĩnh, đạo đức, năng lực lãnh đạo; phát huy dân chủ nội bộ gắn với nguyên tắc tập trung dân chủ, tự phê bình và phê bình.
-
-3. **Xây dựng Nhà nước pháp quyền xã hội chủ nghĩa vững mạnh** để thực thi dân chủ. Nhà nước dưới sự lãnh đạo của Đảng phải thể hiện quyền làm chủ của nhân dân trên mọi lĩnh vực; mọi chính sách, pháp luật phải xuất phát từ ý chí, nguyện vọng của nhân dân; bảo đảm quyền con người, quyền công dân trên thực tế.
-
-4. **Nâng cao vai trò của các tổ chức chính trị – xã hội**. Các tổ chức cần đổi mới phương thức hoạt động, tham gia giám sát, phản biện đường lối, chính sách; củng cố khối đại đoàn kết toàn dân; chăm lo đời sống nhân dân; tham gia xây dựng Đảng, chính quyền và bảo vệ quyền lợi chính đáng của nhân dân.
-
-5. **Hoàn thiện hệ thống giám sát, phản biện xã hội** nhằm phát huy quyền làm chủ của nhân dân. Cần công khai, minh bạch thông tin; cụ thể hóa cơ chế lắng nghe ý kiến nhân dân; nâng cao dân trí, văn hóa pháp luật; tạo điều kiện để nhân dân tham gia góp ý, giám sát đối với chủ trương, chính sách.
-
-
-
-#### 3.2. Tiếp tục xây dựng và hoàn thiện Nhà nước pháp quyền xã hội chủ nghĩa
-1. **Xây dựng Nhà nước pháp quyền dưới sự lãnh đạo của Đảng** với bản chất giai cấp công nhân, gắn bó với dân tộc và nhân dân; bảo đảm quyền lực nhà nước thống nhất, có phân công và phối hợp giữa lập pháp, hành pháp, tư pháp.
-
-2. **Cải cách thể chế và phương thức hoạt động của Nhà nước**: kiện toàn tổ chức và nâng cao hiệu quả của Quốc hội – cơ quan quyền lực cao nhất; xây dựng nền hành chính dân chủ, trong sạch, hiện đại; đẩy mạnh cải cách thủ tục; nâng cao năng lực thực thi chính sách; xã hội hóa dịch vụ công phù hợp định hướng xã hội chủ nghĩa.
-
-3. **Xây dựng đội ngũ cán bộ, công chức trong sạch, có năng lực**: nâng cao phẩm chất chính trị, đạo đức, năng lực quản lý; có chính sách đãi ngộ, khuyến khích hoàn thành nhiệm vụ; thiết lập cơ chế loại bỏ những người yếu kém, vi phạm kỷ luật.
-
-4. **Đấu tranh phòng, chống tham nhũng, lãng phí, thực hành tiết kiệm**: hoàn thiện thể chế, cải cách hành chính phục vụ phòng chống tham nhũng; khuyến khích, bảo vệ người đấu tranh; xử lý nghiêm tổ chức, cá nhân vi phạm; động viên toàn xã hội thực hành tiết kiệm.
-`,
-            english: `
-
-
-## III. Socialist Democracy and the Socialist Rule-of-Law State in Vietnam
-
-### 3. Promoting Socialist Democracy and Building the Socialist Rule-of-Law State Today
-
-#### 3.1. Advancing Socialist Democracy in Contemporary Vietnam
-1. **Develop and perfect the socialist-oriented market economy** to provide a solid economic foundation for socialist democracy. This entails codifying policies on diverse ownership forms and economic sectors; protecting lawful property rights; establishing legal frameworks for new asset classes; and aligning institutional design from promulgation to implementation and oversight. Administrative procedures must be overhauled, market factors developed synchronously, and business regulations updated to fit Vietnam’s context.
-
-2. **Build a pure and strong Communist Party of Vietnam**, the prerequisite for socialist democracy. The Party must be firm in politics, ideology, and organization; continuously renew and rectify itself; enhance intellectual capacity, political bravery, ethics, and leadership; and democratize internal life through democratic centralism, self-criticism, and criticism.
-
-3. **Establish a strong socialist rule-of-law state** to realize democracy. Under Party leadership, the state must reflect the people’s mastery in every domain; all policies and laws must stem from the people’s will; human and citizen rights must be guaranteed in law and practice.
-
-4. **Elevate the role of socio-political organizations** by renewing operational methods, engaging in oversight and policy feedback, consolidating great national unity, caring for the people’s livelihoods, contributing to Party and state building, and defending legitimate interests.
-
-5. **Improve systems of social oversight and feedback** so the people can exercise mastery. Information and policies must be transparent; mechanisms for listening to citizens institutionalized; civic education and legal awareness enhanced; and favorable conditions created for public input on national development issues.
-
-
-
-#### 3.2. Continuing to Build and Perfect the Socialist Rule-of-Law State
-1. **Build the rule-of-law state under Party leadership**, maintaining its working-class nature, close ties to the nation and people, and unified state power with coordinated legislative, executive, and judicial functions.
-
-2. **Reform institutions and state operations**: streamline the National Assembly’s organization and effectiveness as the highest organ of power; develop a democratic, clean, modern public administration; accelerate administrative reform; improve policy execution; and appropriately socialize public services consistent with the socialist-oriented market economy.
-
-3. **Develop a clean, competent cadre and civil-service corps** by enhancing political qualities, ethics, and governance capacity; applying incentive policies; and creating mechanisms to remove officials who underperform or violate discipline.
-
-4. **Combat corruption and waste while promoting thrift** by perfecting institutions, advancing administrative reform, protecting whistle-blowers, enforcing strict sanctions, and mobilizing society-wide thrift practices.
-`,
-        },
-        excerpt: {
-            vietnamese:
-                'Đề xuất các giải pháp phát huy dân chủ và hoàn thiện Nhà nước pháp quyền xã hội chủ nghĩa trong giai đoạn hiện nay.',
-            english:
-                'Presents measures to advance socialist democracy and perfect Vietnam’s socialist rule-of-law state today.',
-        },
-        author: 'Admin',
-        date: '2024-05-25',
-        readTime: {
-            vietnamese: '24 phút',
-            english: '24 minutes',
-        },
-        image: '/assets/blog-images/4.3.3-thumbnail.png',
-        originalLanguage: 'vietnamese' as const,
-        quiz: {
-            vietnamese: [
-                {
-                    question: 'Theo nội dung văn bản, cải cách hành chính có tác động trực tiếp gì?',
-                    options: [
-                        'Giảm vai trò của pháp luật',
-                        'Nhanh chóng cải thiện môi trường kinh doanh',
-                        'Bãi bỏ giám sát xã hội',
-                        'Tăng hình thức thủ tục',
-                    ],
-                    correct: 1,
-                },
-            ],
-            english: [
-                {
-                    question: 'According to the text, what is a direct effect of administrative reform?',
-                    options: [
-                        'Reducing the role of law',
-                        'Rapidly improving the business environment',
-                        'Eliminating social oversight',
-                        'Increasing procedural formality',
-                    ],
-                    correct: 1,
-                },
-            ],
-        },
-    },
-    12: {
-        id: 12,
-        section: '4.3.4' as SectionId,
-        title: {
-            vietnamese: 'Phòng, chống tham nhũng góp phần bảo vệ chế độ, xây dựng Nhà nước pháp quyền',
-            english: 'Anti-Corruption to Safeguard the Regime and Build the Rule-of-Law State',
-        },
-        content: {
-            vietnamese: `
-
-
-## III. Dân chủ xã hội chủ nghĩa và Nhà nước pháp quyền xã hội chủ nghĩa ở Việt Nam
-
-### 4. Phòng, chống tham nhũng góp phần bảo vệ chế độ, xây dựng Nhà nước pháp quyền
-
-#### 4.1. Khái niệm về tham nhũng
-Tham nhũng là hành vi của người có chức vụ, quyền hạn lợi dụng vị trí đó để vụ lợi. Người có chức vụ, quyền hạn có thể do bổ nhiệm, bầu cử, tuyển dụng hoặc các hình thức khác. “Vụ lợi” bao gồm cả lợi ích vật chất và phi vật chất không chính đáng.
-
-#### 4.2. Đặc điểm của hành vi tham nhũng
-- **Chủ thể đặc thù**: chỉ người có chức vụ, quyền hạn mới có thể thực hiện hành vi tham nhũng.
-- **Lợi dụng chức vụ, quyền hạn**: sử dụng thẩm quyền được giao để làm trái pháp luật nhằm mưu lợi riêng – dấu hiệu phân biệt tham nhũng với các vi phạm khác.
-- **Động cơ vụ lợi**: mục đích là trục lợi cá nhân hoặc nhóm nhỏ; nếu vi phạm không vì vụ lợi thì không phải tham nhũng.
-
-#### 4.3. Các hành vi tham nhũng phổ biến
-Tham ô tài sản; nhận hối lộ; lạm dụng chức vụ chiếm đoạt tài sản; lợi dụng chức vụ khi thi hành nhiệm vụ vì vụ lợi; lạm quyền vì vụ lợi; lợi dụng chức vụ gây ảnh hưởng để trục lợi; giả mạo trong công tác; đưa, môi giới hối lộ; sử dụng trái phép tài sản công vì vụ lợi; nhũng nhiễu; không thực hiện hoặc thực hiện không đúng nhiệm vụ vì vụ lợi; bao che vi phạm hoặc cản trở giám sát, thanh tra, điều tra, truy tố, xét xử, thi hành án vì vụ lợi.
-
-
-#### 4.4. Nguyên nhân của tham nhũng
-Nguyên nhân chủ quan bao gồm: hạn chế trong tổ chức và hoạt động của hệ thống chính trị; cơ chế, chính sách, pháp luật chưa hoàn thiện; nhận thức của người đứng đầu còn yếu; nhiệm vụ của cơ quan phòng chống tham nhũng chưa phân định rõ; pháp luật chưa đủ mạnh; tuyên truyền còn hình thức. Ngoài ra còn có tác động của mặt trái kinh tế thị trường và toàn cầu hóa; hệ thống chính sách thiếu đồng bộ; quản lý nhà nước lỏng lẻo; quản lý cán bộ còn hạn chế; một số nơi chưa đề cao trách nhiệm người đứng đầu; sự suy thoái đạo đức, lối sống của một bộ phận cán bộ, đảng viên.
-
-#### 4.5. Tác hại của tham nhũng
-- **Chính trị**: vi phạm Hiến pháp, Điều lệ Đảng, gây tổn hại cho xã hội.
-- **Kinh tế**: cản trở quản lý, kìm hãm phát triển sản xuất, kinh doanh, dịch vụ.
-- **Xã hội**: làm gia tăng khoảng cách giàu – nghèo, gây rối trật tự, kỷ cương, cản trở mục tiêu công bằng, dân chủ, văn minh.
-- **Văn hóa**: làm suy đồi các giá trị văn hóa, cản trở cải cách tư pháp và xây dựng nhà nước pháp quyền.
-- **Đạo đức**: trái ngược đạo đức cách mạng, phản bội lý tưởng phục vụ nhân dân.
-`,
-            english: `
-
-
-## III. Socialist Democracy and the Socialist Rule-of-Law State in Vietnam
-
-### 4. Combating Corruption to Safeguard the Regime and Build the Rule-of-Law State
-
-#### 4.1. Concept of Corruption
-Corruption is the act of a person holding a position or power who exploits that position for personal gain. Such individuals may be appointed, elected, recruited, or otherwise entrusted. “Personal gain” encompasses illegitimate material and non-material benefits.
-
-#### 4.2. Characteristics
-- **Specific subjects:** only those with official positions or powers can commit corruption.
-- **Abuse of position and power:** using delegated authority to violate the law for self-interest, distinguishing corruption from other offenses.
-- **Profit motive:** corruption aims at personal or small-group benefit; violations without such intent are not deemed corruption.
-
-#### 4.3. Common Corrupt Acts
-Embezzlement; taking bribes; abusing office to appropriate property; misusing authority while performing duties for profit; exceeding authority for profit; leveraging influence for private gain; falsifying official documents; giving or brokering bribes to resolve institutional matters; misappropriating public assets; extortion; neglecting or improperly performing duties for profit; covering up violations or obstructing oversight, inspection, investigation, prosecution, adjudication, and enforcement for profit.
-
-
-
-#### 4.4. Causes of Corruption
-Subjective causes include shortcomings in political institutions; incomplete mechanisms, policies, and laws; limited awareness among leaders; unclear mandates for anti-corruption agencies; insufficient legal deterrence; and superficial propaganda. Additional factors involve the adverse impacts of the market economy and globalization; inconsistent policies; weak state management; inadequate personnel oversight; insufficient accountability of some leaders; and moral degradation among a segment of officials and party members.
-
-#### 4.5. Consequences
-- **Political:** violates the Constitution and Party statutes, harming society.
-- **Economic:** hinders governance and suppresses development in economic sectors and services.
-- **Social:** widens wealth gaps, undermines order and security, and obstructs the goal of a fair, democratic, progressive, civilized society.
-- **Cultural:** erodes cultural values and hinders judicial reform and the building of the rule-of-law state.
-- **Ethical:** betrays revolutionary ethics by placing personal gain above service to the people.
-`,
-        },
-        excerpt: {
-            vietnamese:
-                'Phân tích khái niệm, nguyên nhân và tác hại của tham nhũng, nhấn mạnh vai trò của phòng, chống tham nhũng.',
-            english:
-                'Analyzes the nature, causes, and harm of corruption while underscoring the importance of anti-corruption efforts.',
-        },
-        author: 'Admin',
-        date: '2024-05-25',
-        readTime: {
-            vietnamese: '18 phút',
-            english: '18 minutes',
-        },
-        image: '/assets/blog-images/4.3.4-thumbnail.png',
-        originalLanguage: 'vietnamese' as const,
-        quiz: {
-            vietnamese: [
-                {
-                    question: 'Dấu hiệu đặc trưng phân biệt hành vi tham nhũng với vi phạm pháp luật khác là gì?',
-                    options: [
-                        'Do bất kỳ công dân nào thực hiện',
-                        'Mang tính tập thể',
-                        'Lợi dụng chức vụ, quyền hạn được giao để vụ lợi',
-                        'Không nhằm mục đích tư lợi',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'Hành vi nào sau đây thuộc nhóm hành vi tham nhũng theo liệt kê trong văn bản?',
-                    options: [
-                        'Tố cáo hành vi vi phạm đến cơ quan có thẩm quyền',
-                        'Nhận hối lộ',
-                        'Tự phê bình và phê bình trong Đảng',
-                        'Tiết kiệm chi tiêu công',
-                    ],
-                    correct: 1,
-                },
-            ],
-            english: [
-                {
-                    question: 'What distinguishing feature sets corruption apart from other legal violations?',
-                    options: [
-                        'It can be committed by any citizen',
-                        'It is necessarily collective in nature',
-                        'It involves abusing assigned position or power for personal gain',
-                        'It has no profit motive',
-                    ],
-                    correct: 2,
-                },
-                {
-                    question: 'Which of the following is listed as a corrupt act in the text?',
-                    options: [
-                        'Reporting violations to a competent authority',
-                        'Accepting a bribe',
-                        'Practicing self-criticism within the Party',
-                        'Implementing public spending cuts',
-                    ],
-                    correct: 1,
-                },
-            ],
-        },
-    },
-    13: {
-        id: 13,
-        section: '4.3.5' as SectionId,
-        title: {
-            vietnamese: 'Trách nhiệm của công dân trong phòng, chống tham nhũng',
-            english: 'Citizen Responsibilities in Combating Corruption',
-        },
-        content: {
-            vietnamese: `
-
-
-## III. Dân chủ xã hội chủ nghĩa và Nhà nước pháp quyền xã hội chủ nghĩa ở Việt Nam
-
-### 5. Trách nhiệm của công dân trong phòng, chống tham nhũng
-
-#### 5.1. Chấp hành nghiêm chỉnh pháp luật về phòng, chống tham nhũng
-Mỗi công dân – nhất là người có chức vụ, quyền hạn – phải “giữ mình”, không lợi dụng quyền lực để tham nhũng; đồng thời giáo dục, vận động người thân tuân thủ pháp luật. Ý thức chấp hành là nền tảng để lên án, tố giác, đấu tranh với tham nhũng.
-
-
-
-#### 5.2. Lên án, đấu tranh với hành vi tham nhũng
-Chủ động phê phán, nhắc nhở và lên án hành vi sai trái, tạo dư luận xã hội mạnh mẽ nhằm răn đe tham nhũng; thể hiện thái độ không dung thứ.
-
-#### 5.3. Phát hiện, tố cáo hành vi tham nhũng
-Theo Điều 64 Luật Phòng, chống tham nhũng, công dân có quyền và nghĩa vụ tố cáo hành vi tham nhũng thông qua hai hình thức: phản ánh với Ban thanh tra nhân dân hoặc tổ chức mà mình là thành viên; tố cáo trực tiếp đến cơ quan, cá nhân có thẩm quyền. Người tố cáo phải cung cấp thông tin khách quan, trung thực, chịu trách nhiệm về nội dung tố cáo và được bảo vệ bí mật.
-
-#### 5.4. Hợp tác với cơ quan có thẩm quyền
-Công dân có nghĩa vụ hỗ trợ, cung cấp thông tin, tài liệu khi được yêu cầu; việc không hợp tác, gây cản trở có thể bị xử lý theo quy định của Bộ luật Hình sự.
-
-#### 5.5. Kiến nghị hoàn thiện cơ chế, chính sách pháp luật
-Khi phát hiện “lỗ hổng pháp luật” dễ bị lợi dụng, công dân có quyền kiến nghị sửa đổi, bổ sung cơ chế, chính sách; yêu cầu cơ quan, đơn vị cung cấp thông tin để giám sát; góp phần làm cho pháp luật hoàn thiện hơn.
-
-#### 5.6. Góp ý xây dựng pháp luật về phòng, chống tham nhũng
-Công dân có thể tham gia thông qua hội nghị, diễn đàn, tổ chức chính trị – xã hội; phân tích, đánh giá quy định pháp luật, dự báo tình hình để góp ý; giúp pháp luật thiết thực, khả thi và hiệu quả.
-`,
-            english: `
-
-
-## III. Socialist Democracy and the Socialist Rule-of-Law State in Vietnam
-
-### 5. Citizens’ Responsibilities in Combating Corruption
-
-#### 5.1. Comply Strictly with Anti-Corruption Laws
-Every citizen—especially those holding office—must remain upright, avoid abusing power for private gain, and encourage relatives to obey the law. Legal compliance forms the basis for denouncing and fighting corruption.
-
-
-
-#### 5.2. Denounce and Oppose Corrupt Acts
-Citizens should actively criticize, admonish, and condemn wrongdoing, thereby shaping strong public opinion against corruption and showing zero tolerance for it.
-
-#### 5.3. Detect and Report Corruption
-Under Article 64 of the Law on Anti-Corruption, citizens have both the right and duty to report corruption through two channels: informing the people’s inspection board or organizations of which they are members, and reporting directly to competent authorities or individuals. Whistle-blowers must provide objective, truthful information, take responsibility for their statements, and are entitled to confidentiality and protection.
-
-#### 5.4. Cooperate with Competent Agencies
-Citizens are obliged to assist and provide information and documents when requested; failure to cooperate or obstruct investigations can lead to sanctions under the Penal Code.
-
-#### 5.5. Recommend Improvements to Policies and Laws
-When legal loopholes that may be exploited for corruption are identified, citizens can propose amendments, request information for oversight, and contribute to improving the legal framework.
-
-#### 5.6. Contribute to Lawmaking on Anti-Corruption
-Participation can occur through conferences, forums, and socio-political organizations. Citizens analyze regulations, assess their practicality, and forecast trends to offer feedback that makes laws more realistic, feasible, and effective.
-`,
-        },
-        excerpt: {
-            vietnamese:
-                'Nhấn mạnh vai trò, quyền và nghĩa vụ của công dân trong việc phát hiện, tố cáo và phòng, chống tham nhũng.',
-            english:
-                'Emphasizes citizens’ roles, rights, and duties in detecting, reporting, and preventing corruption.',
-        },
-        author: 'Admin',
-        date: '2024-05-25',
-        readTime: {
-            vietnamese: '12 phút',
-            english: '12 minutes',
+            vietnamese: '15 phút',
+            english: '15 minutes',
         },
         image: '/assets/blog-images/4.3.5-thumbnail.png',
         originalLanguage: 'vietnamese' as const,
         quiz: {
             vietnamese: [
                 {
-                    question: 'Theo quy định nêu trong văn bản, công dân có thể thực hiện tố cáo hành vi tham nhũng bằng những hình thức nào?',
+                    question:
+                        'Theo Hồ Chí Minh, đạo đức là gì đối với người cách mạng?',
                     options: [
-                        'Chỉ qua mạng xã hội',
-                        'Chỉ gửi Quốc hội',
-                        'Phản ánh với Ban thanh tra nhân dân/tổ chức mình là thành viên hoặc tố cáo trực tiếp đến cơ quan, cá nhân có thẩm quyền',
-                        'Chỉ thông qua tòa án',
+                        'Một phẩm chất phụ',
+                        'Là nền tảng, gốc rễ',
+                        'Một kỹ năng lãnh đạo',
+                        'Một chuẩn mực xã hội phụ thuộc',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question:
+                        'Câu nói “Người cách mạng phải có đạo đức, không có đạo đức thì dù tài giỏi mấy cũng không lãnh đạo được nhân dân” nhấn mạnh điều gì?',
+                    options: [
+                        'Đức quan trọng hơn tài',
+                        'Tài là điều kiện đủ',
+                        'Đức và tài tách rời',
+                        'Tài năng quyết định tất cả',
+                    ],
+                    correct: 0,
+                },
+                {
+                    question: 'Trong tư tưởng Hồ Chí Minh, “hồng” được hiểu là gì?',
+                    options: [
+                        'Tài năng',
+                        'Chuyên môn',
+                        'Phẩm chất chính trị, đạo đức',
+                        'Ý chí rèn luyện',
                     ],
                     correct: 2,
+                },
+                {
+                    question: 'Trong tư tưởng Hồ Chí Minh, “chuyên” có nghĩa là gì?',
+                    options: [
+                        'Trình độ chuyên môn, kỹ năng',
+                        'Đạo đức trong hành động',
+                        'Lòng nhân ái',
+                        'Trung thành tuyệt đối',
+                    ],
+                    correct: 0,
+                },
+                {
+                    question: 'Hồ Chí Minh coi chuẩn mực cao nhất của đạo đức là gì?',
+                    options: [
+                        'Lý thuyết cách mạng',
+                        'Nói đi đôi với làm',
+                        'Phục tùng cấp trên',
+                        'Đặt lợi ích cá nhân trước',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question:
+                        'Trong giai đoạn 1945, Hồ Chí Minh đã nêu gương đạo đức bằng việc nào?',
+                    options: [
+                        'Tặng chiếc nhẫn vàng duy nhất trong “Tuần lễ vàng”',
+                        'Phát động cải cách ruộng đất',
+                        'Tự viết sách lý luận',
+                        'Kêu gọi đoàn kết dân tộc',
+                    ],
+                    correct: 0,
+                },
+                {
+                    question:
+                        '“Trung với nước, hiếu với dân” theo Hồ Chí Minh được hiểu là gì?',
+                    options: [
+                        'Trung thành với vua, hiếu với cha mẹ',
+                        'Trung thành với Tổ quốc, hiếu với toàn dân',
+                        'Trung với Đảng, hiếu với lãnh đạo',
+                        'Trung thành với bạn bè, hiếu với gia đình',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question:
+                        'Trong 4 đức tính cần, kiệm, liêm, chính thì “Liêm” nghĩa là gì?',
+                    options: [
+                        'Sống giản dị',
+                        'Không tham lam, trong sạch',
+                        'Cần cù lao động',
+                        'Chí công vô tư',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question: 'Theo Hồ Chí Minh, “Cần” là gì?',
+                    options: [
+                        'Không xa xỉ',
+                        'Chăm chỉ, siêng năng, lao động sáng tạo',
+                        'Thẳng thắn, không nịnh hót',
+                        'Hoàn toàn vì lợi ích chung',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question: 'Trong tư tưởng Hồ Chí Minh, “Chí công vô tư” là gì?',
+                    options: [
+                        'Đặt lợi ích cá nhân lên trên',
+                        'Công bằng, công tâm, vì lợi ích chung',
+                        'Sống giản dị, tiết kiệm',
+                        'Chăm chỉ lao động',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question:
+                        'Đạo đức cách mạng giúp con người thế nào khi gặp khó khăn?',
+                    options: [
+                        'Tìm sự hỗ trợ bên ngoài',
+                        'Vững vàng, không sợ sệt, không lùi bước',
+                        'Tạm dừng công việc',
+                        'Tránh né thử thách',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question:
+                        'Nguyên tắc quan trọng nhất trong xây dựng đạo đức cách mạng là gì?',
+                    options: [
+                        'Tự rèn luyện',
+                        'Nói đi đôi với làm, nêu gương',
+                        'Học tập lý luận',
+                        'Tôn trọng pháp luật',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question:
+                        'Theo Hồ Chí Minh, cán bộ nói một đằng làm một nẻo là biểu hiện của điều gì?',
+                    options: [
+                        'Đạo đức giả',
+                        'Đạo đức thực chất',
+                        'Đạo đức mới',
+                        'Tu dưỡng liên tục',
+                    ],
+                    correct: 0,
+                },
+                {
+                    question:
+                        'Quan điểm “xây đi đôi với chống” có nghĩa là gì?',
+                    options: [
+                        'Chỉ xây, không chống',
+                        'Chỉ chống, không xây',
+                        'Xây dựng đạo đức mới đồng thời chống cái xấu',
+                        'Xây dựng pháp luật là chính',
+                    ],
+                    correct: 2,
+                },
+                {
+                    question: 'Nguồn gốc của mọi tệ nạn theo Hồ Chí Minh là gì?',
+                    options: [
+                        'Chủ nghĩa cá nhân',
+                        'Chủ nghĩa tập thể',
+                        'Thiếu tri thức',
+                        'Nghèo đói',
+                    ],
+                    correct: 0,
+                },
+                {
+                    question: 'Tu dưỡng đạo đức theo Hồ Chí Minh phải được tiến hành thế nào?',
+                    options: [
+                        'Một lần trong đời',
+                        'Liên tục, suốt đời',
+                        'Chỉ khi có chức vụ',
+                        'Chỉ trong gian khổ',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question: 'Tinh thần quốc tế trong sáng là gì?',
+                    options: [
+                        'Đoàn kết với vô sản toàn thế giới',
+                        'Chỉ lo cho dân tộc mình',
+                        'Đặt lợi ích cá nhân lên trên hết',
+                        'Tránh mọi quan hệ quốc tế',
+                    ],
+                    correct: 0,
+                },
+                {
+                    question:
+                        'Theo Hồ Chí Minh, yêu thương con người thể hiện rõ nhất ở đối tượng nào?',
+                    options: [
+                        'Người giàu có',
+                        'Người nghèo khổ, bị áp bức',
+                        'Người học giỏi',
+                        'Người có quyền lực',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question: 'Người yêu cầu trong tình nghĩa với con người phải như thế nào?',
+                    options: [
+                        'Nghiêm khắc với mình, rộng lượng với người',
+                        'Dễ dãi với bản thân',
+                        'Khắt khe với tất cả',
+                        'Tập trung lợi ích riêng',
+                    ],
+                    correct: 0,
+                },
+                {
+                    question:
+                        'Câu “Đầu tiên là công việc đối với con người...” trong Di chúc thể hiện điều gì?',
+                    options: [
+                        'Lòng yêu thương con người',
+                        'Tinh thần quốc tế',
+                        'Nguyên tắc xây – chống',
+                        'Chí công vô tư',
+                    ],
+                    correct: 0,
                 },
             ],
             english: [
                 {
-                    question: 'According to the text, which channels may citizens use to report corruption?',
+                    question:
+                        'According to Hồ Chí Minh, what are ethics to a revolutionary?',
                     options: [
-                        'Only via social media',
-                        'Only by petitioning the National Assembly',
-                        'By informing the people’s inspection board/organizations they belong to or reporting directly to competent authorities',
-                        'Only through the courts',
+                        'A secondary quality',
+                        'The foundation and roots',
+                        'A leadership skill',
+                        'A contingent social norm',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question:
+                        'The saying “Revolutionaries must have ethics; without ethics, no matter how talented, they cannot lead the people” stresses what?',
+                    options: [
+                        'Morality outweighs talent',
+                        'Talent is the sufficient condition',
+                        'Morality and talent are separate',
+                        'Talent decides everything',
+                    ],
+                    correct: 0,
+                },
+                {
+                    question: 'In Hồ Chí Minh’s thought, what does “redness” mean?',
+                    options: [
+                        'Talent',
+                        'Professionalism',
+                        'Political and moral qualities',
+                        'The will to practise',
                     ],
                     correct: 2,
+                },
+                {
+                    question: 'In Hồ Chí Minh’s thought, what does “expertness” signify?',
+                    options: [
+                        'Professional competence and skills',
+                        'Ethics in action',
+                        'Compassion',
+                        'Absolute loyalty',
+                    ],
+                    correct: 0,
+                },
+                {
+                    question: 'What did Hồ Chí Minh regard as the highest ethical standard?',
+                    options: [
+                        'Revolutionary theory',
+                        'Words matching deeds',
+                        'Obedience to superiors',
+                        'Putting personal interests first',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question:
+                        'In 1945, which deed showed Hồ Chí Minh’s ethical example?',
+                    options: [
+                        'Donating his only gold ring during the “Week of Gold”',
+                        'Launching land reform',
+                        'Writing theoretical books himself',
+                        'Calling for national unity',
+                    ],
+                    correct: 0,
+                },
+                {
+                    question:
+                        'How did Hồ Chí Minh reinterpret “loyalty and filial piety”?',
+                    options: [
+                        'Loyal to the king, filial to parents',
+                        'Loyal to the Fatherland, devoted to the people',
+                        'Loyal to the Party, filial to leaders',
+                        'Loyal to friends, filial to family',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question:
+                        'Among the virtues diligence, thrift, integrity, righteousness, what does “integrity” mean?',
+                    options: [
+                        'Living simply',
+                        'Being uncorrupted and ungreedy',
+                        'Working diligently',
+                        'Being absolutely selfless',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question: 'According to Hồ Chí Minh, what is “diligence”?',
+                    options: [
+                        'Avoiding extravagance',
+                        'Industrious, creative labour',
+                        'Being frank and not flattering',
+                        'Serving the common good entirely',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question: 'What is “absolute selflessness” in Hồ Chí Minh’s view?',
+                    options: [
+                        'Placing personal benefit first',
+                        'Being fair, impartial, and for the common good',
+                        'Living simply and thriftily',
+                        'Working diligently',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question:
+                        'How do revolutionary ethics support people in hard times?',
+                    options: [
+                        'By seeking outside help',
+                        'By keeping them steadfast, fearless, and unwavering',
+                        'By pausing their tasks',
+                        'By avoiding challenges',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question:
+                        'What is the foremost principle in building revolutionary ethics?',
+                    options: [
+                        'Self-training',
+                        'Matching words with deeds and setting an example',
+                        'Studying theory',
+                        'Respecting the law',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question:
+                        'According to Hồ Chí Minh, what does it mean when cadres say one thing but do another?',
+                    options: [
+                        'Hypocrisy',
+                        'Genuine ethics',
+                        'New ethics',
+                        'Continuous cultivation',
+                    ],
+                    correct: 0,
+                },
+                {
+                    question: 'What does the viewpoint “building must go with combating” mean?',
+                    options: [
+                        'Only building, no combating',
+                        'Only combating, no building',
+                        'Building new ethics while resisting wrongdoing',
+                        'Focusing mainly on legal construction',
+                    ],
+                    correct: 2,
+                },
+                {
+                    question:
+                        'What did Hồ Chí Minh identify as the root of every vice?',
+                    options: [
+                        'Individualism',
+                        'Collectivism',
+                        'Lack of knowledge',
+                        'Poverty',
+                    ],
+                    correct: 0,
+                },
+                {
+                    question: 'How must ethical cultivation be carried out according to Hồ Chí Minh?',
+                    options: [
+                        'Once in a lifetime',
+                        'Continuously, throughout life',
+                        'Only when holding office',
+                        'Only during hardship',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question: 'What is a “pure international spirit”?',
+                    options: [
+                        'Solidarity with the world proletariat',
+                        'Caring only for one’s own nation',
+                        'Putting personal interests above all',
+                        'Avoiding international relations',
+                    ],
+                    correct: 0,
+                },
+                {
+                    question:
+                        'According to Hồ Chí Minh, whom should our love for humanity focus on most?',
+                    options: [
+                        'The wealthy',
+                        'The poor and the oppressed',
+                        'High achievers',
+                        'Those in power',
+                    ],
+                    correct: 1,
+                },
+                {
+                    question:
+                        'What ethical requirement did he set for dealings with people?',
+                    options: [
+                        'Be strict with oneself and generous with others',
+                        'Be indulgent with oneself',
+                        'Be harsh with everyone',
+                        'Focus on personal gain',
+                    ],
+                    correct: 0,
+                },
+                {
+                    question:
+                        'The Testament line “First is work for people...” expresses what?',
+                    options: [
+                        'Love for humanity',
+                        'Internationalism',
+                        'The build-and-fight principle',
+                        'Absolute selflessness',
+                    ],
+                    correct: 0,
                 },
             ],
         },
     },
+    2: {
+        id: 2,
+        section: '6.2' as SectionId,
+        title: {
+            vietnamese: 'Chuẩn mực đạo đức cách mạng',
+            english: 'Standards of revolutionary ethics',
+        },
+        content: {
+            vietnamese: `
+Chương 6: Tư tưởng Hồ Chí Minh về văn hóa, đạo đức, con người
 
-}
+2. Quan điểm của Hồ Chí Minh về những chuẩn mực đạo đức cách mạng
+
+a) Trung với nước, hiếu với dân
+- Trung với nước, hiếu với dân là phẩm chất đạo đức bao trùm quan trọng nhất và chi phối các phẩm chất khác.
+- Trung và hiếu vốn thuộc truyền thống “trung với vua, hiếu với cha mẹ”; Hồ Chí Minh nâng lên thành “trung với nước, hiếu với dân”.
+- “Đạo đức cũ như người đầu ngược xuống đất, chân chống lên trời. Đạo đức mới như người hai chân đứng vững dưới đất, đầu ngẩng lên trời.”
+- Trung với nước là trung thành với sự nghiệp dựng nước và giữ nước: yêu nước, tuyệt đối trung thành với Tổ quốc, suốt đời phấn đấu cho Đảng, cho cách mạng, làm cho “dân giàu, nước mạnh”.
+- Hiếu với dân là thương dân, tin dân, thân dân, học hỏi dân, lấy trí tuệ ở dân, kính trọng dân, lấy dân làm gốc, “hết lòng hết sức phục vụ nhân dân... Tuyệt đối không được lên mặt ‘quan cách mạng’ ra lệnh ra oai.” (Hồ Chí Minh: Toàn tập, Nxb Chính trị quốc gia Hà Nội, 2011, t.13, tr.67).
+
+b) Cần, kiệm, liêm, chính, chí công vô tư
+- Đây là nội dung cốt lõi của đạo đức cách mạng, gắn với hoạt động hằng ngày của mỗi người.
+- Cần là lao động có kế hoạch, sáng tạo, năng suất cao; lao động với tinh thần tự lực, không lười biếng. “Lao động là nghĩa vụ thiêng liêng, là nguồn sống, nguồn hạnh phúc của chúng ta.” (t.13, tr.69).
+- Kiệm là tiết kiệm sức lao động, thời gian, tiền của của dân, của nước, của bản thân; không phô trương hình thức. “Tiết kiệm không phải là bủn xỉn... Khi có việc ích nước lợi dân thì dù tốn bao nhiêu cũng vui lòng.”
+- Liêm là trong sạch, không tham lam địa vị, tiền tài, sung sướng hay lời tâng bốc. “Có Kiệm thì mới Liêm được.” (t.6, tr.126).
+- Chính là thẳng thắn, đứng đắn, không nịnh hót người trên, không khinh người dưới, thật thà, không dối trá. “Đối với mình – chớ tự kiêu, tự đại. Đối với người – chớ nịnh hót người trên. Chớ xem khinh người dưới.”
+- Chí công vô tư là hoàn toàn vì lợi ích chung, công bằng, công tâm, đặt lợi ích của Đảng, của nhân dân, của dân tộc lên trên hết; chống chủ nghĩa cá nhân. “Đem lòng chí công vô tư mà đối với người, với việc... Khi làm bất cứ việc gì cũng đừng nghĩ đến mình trước, khi hưởng thụ thì mình nên đi sau.”
+- Hồ Chí Minh ví bốn đức cần, kiệm, liêm, chính như bốn mùa của trời, bốn phương của đất; thiếu một đức thì không thành người.
+
+c) Thương yêu con người, sống có tình nghĩa
+- Đây là phẩm chất đạo đức cao đẹp nhất, kết tinh truyền thống nhân nghĩa với chủ nghĩa nhân đạo cộng sản.
+- Đối tượng trước hết là những người nghèo khổ, bị mất quyền, bị áp bức bóc lột không phân biệt màu da, dân tộc.
+- Yêu đồng loại, yêu đồng bào, yêu đất nước là mục tiêu phấn đấu, là nền tảng tư tưởng đạo đức Hồ Chí Minh.
+- Trong thực hành, phải đứng trên lập trường giai cấp công nhân, thể hiện trong các quan hệ hằng ngày bằng hành động cụ thể, thiết thực.
+- Yêu cầu: nghiêm khắc với mình; rộng rãi, độ lượng, giàu lòng vị tha với người; tôn trọng quyền con người, tạo điều kiện phát huy tài năng; nâng con người lên, kể cả người lầm lạc, không “dĩ hòa vi quý”, không hạ thấp hay vùi dập.
+- Hồ Chí Minh nhấn mạnh: “Hiểu chủ nghĩa Mác – Lênin là phải sống với nhau có tình có nghĩa... Nếu thuộc bao nhiêu sách mà không có tình có nghĩa thì sao gọi là hiểu.” Trong Di chúc, Người viết: “Đầu tiên là công việc đối với con người... Phải có tình đồng chí thương yêu lẫn nhau.”
+
+d) Tinh thần quốc tế trong sáng
+- Xuất phát từ bản chất giai cấp công nhân, mở rộng quan hệ vượt khỏi giới hạn quốc gia dân tộc.
+- Đó là sự tôn trọng, hiểu biết, thương yêu và đoàn kết với giai cấp vô sản toàn thế giới, với các dân tộc bị áp bức, với nhân dân tiến bộ khắp năm châu.
+- “Quan sơn muôn dặm một nhà / Bốn phương vô sản đều là anh em!” (Hồ Chí Minh: Toàn tập, t.12, tr.670).
+- Đồng thời phải chống chia rẽ, thù hằn, bất bình đẳng, phân biệt chủng tộc; chống chủ nghĩa dân tộc hẹp hòi, sô-vanh, biệt lập; chống chủ nghĩa bành trướng bá quyền.
+- Chủ trương đối thoại thay vì đối đầu, kiến tạo nền văn hóa hòa bình cho nhân loại – di sản vô giá của Người về hòa bình, hữu nghị, hợp tác phát triển.
+`,
+            english: `
+Chapter 6: Hồ Chí Minh's Thought on Culture, Ethics, and Humanity
+
+2. Hồ Chí Minh’s views on the standards of revolutionary ethics
+
+a) Loyalty to the nation, devotion to the people
+- “Loyal to the nation, devoted to the people” is the overarching virtue that governs all others.
+- Drawing from the tradition “loyal to the king, filial to parents,” he expanded it into “loyal to the nation, devoted to the people.”
+- “Old ethics resemble a person standing on their head with feet in the air. New ethics resemble a person standing firmly on the ground with head held high.”
+- Loyalty to the nation means absolute faithfulness to national construction and defence—loving the motherland, lifelong devotion to the Party and the revolution, striving for “a wealthy people and a strong country.”
+- Devotion to the people means loving, trusting, and being close to the people, learning from them, drawing wisdom from them, respecting them, taking them as the root, and “wholeheartedly serving the people... Never assume a ‘revolutionary mandarin’ attitude.” (Collected Works, vol.13, p.67).
+
+b) Diligence, thrift, integrity, righteousness, absolute selflessness
+- These form the core of revolutionary ethics and relate to everyone’s daily conduct.
+- Diligence means planned, creative, high-productivity labour with a spirit of self-reliance. “Labour is our sacred duty, the source of our life and happiness.” (vol.13, p.69).
+- Thrift means saving labour, time, and resources of the people, the nation, and oneself; avoiding ostentation. “Thrift is not miserliness... When something benefits the country and the people, no matter the cost, we gladly accept it.”
+- Integrity means being clean, uncorrupted, untempted by position, wealth, comfort, or flattery. “Only with thrift can one remain upright.” (vol.6, p.126).
+- Righteousness means being frank, proper, not flattering superiors, not despising subordinates, being honest, never deceitful. “Toward oneself—avoid arrogance. Toward others—do not flatter superiors, do not scorn subordinates.”
+- Absolute selflessness means wholly serving the common interest, being fair and impartial, placing the Party’s, the people’s, and the nation’s interests above all, and combating individualism. “Approach people and work with an absolutely selfless heart... When doing anything, do not think of yourself first; when enjoying benefits, place yourself last.”
+- He likened diligence, thrift, integrity, righteousness to the four seasons and directions; lacking one virtue means one cannot be truly human.
+
+c) Loving humanity and living compassionately
+- This is the noblest virtue, blending national benevolence with communist humanism.
+- The primary beneficiaries are the poor, the dispossessed, and the oppressed regardless of race or ethnicity.
+- Loving fellow humans, compatriots, and the homeland is both an aspiration and the foundation of Hồ Chí Minh’s ethical thought.
+- In practice, it must rest on the working-class standpoint, expressed daily through concrete, practical actions.
+- Requirements: be strict with oneself; be generous, tolerant, and forgiving toward others; respect human rights and create conditions for talent to flourish; uplift people—including those who have erred—without easy compromise, degradation, or repression.
+- He stressed: “To understand Marxism–Leninism is to live with affection and loyalty... No matter how many books one reads, without affection and loyalty, one cannot claim understanding.” In his Testament he wrote: “First comes work toward people... We must cherish comradeship and mutual love.”
+
+d) Pure international spirit
+- Rooted in the working-class nature, it expands solidarity beyond national boundaries.
+- It signifies respect, understanding, love, and unity with the world proletariat, oppressed peoples, and progressive humanity everywhere.
+- “Though mountains and rivers are far apart, we share one home; workers of the four directions are brothers all!” (Collected Works, vol.12, p.670).
+- It requires resisting division, hatred, inequality, and racism; opposing narrow nationalism, chauvinism, isolationism; and countering expansionism and hegemonism.
+- It champions dialogue over confrontation, fostering a culture of peace for humanity—the invaluable legacy he left on peace, friendship, and cooperative development.
+`,
+        },
+        excerpt: {
+            vietnamese:
+                'Phân tích bốn nhóm chuẩn mực: trung với nước hiếu với dân, cần kiệm liêm chính chí công vô tư, yêu thương con người và tinh thần quốc tế.',
+            english:
+                'Explores four key standards—loyalty to the nation and people, diligence–thrift–integrity–righteousness–selflessness, love for humanity, and a pure international spirit.',
+        },
+        author: 'Admin',
+        date: '2024-11-15',
+        readTime: {
+            vietnamese: '18 phút',
+            english: '18 minutes',
+        },
+        image: '/assets/blog-images/4.3.5-thumbnail.png',
+        originalLanguage: 'vietnamese' as const,
+    },
+    3: {
+        id: 3,
+        section: '6.3' as SectionId,
+        title: {
+            vietnamese: 'Nguyên tắc tu dưỡng và vận dụng thực tiễn',
+            english: 'Principles of cultivation and practical application',
+        },
+        content: {
+            vietnamese: `
+Chương 6: Tư tưởng Hồ Chí Minh về văn hóa, đạo đức, con người
+
+3. Quan điểm về những nguyên tắc xây dựng đạo đức cách mạng
+
+a) Nói đi đôi với làm, nêu gương về đạo đức
+- Đây là nguyên tắc quan trọng bậc nhất, thống nhất giữa lý luận và thực tiễn. “Đảng viên đi trước, làng nước theo sau.”
+- Hồ Chí Minh phê phán thói đạo đức giả: “Miệng thì nói dân chủ nhưng làm việc thì họ theo lối ‘quan’ chủ...”.
+- Người yêu cầu cán bộ phải làm gương về tinh thần, vật chất và văn hóa: “Trước hết mình phải làm gương...”. (Hồ Chí Minh: Toàn tập, t.4, tr.171).
+- Sự gương mẫu của cán bộ là phương pháp giáo dục đạo đức sâu sắc nhất; chuẩn mực chỉ có sức sống khi trở thành hành vi hằng ngày của mỗi người.
+
+b) Xây đi đôi với chống
+- Xây là xây dựng giá trị, chuẩn mực đạo đức mới; chống là đấu tranh với biểu hiện suy thoái, cái xấu, cái ác.
+- Muốn xây phải chống, chống nhằm mục đích xây, lấy xây làm chính – khơi dậy ý thức tự giáo dục, tự trau dồi đạo đức.
+- Hồ Chí Minh chỉ rõ nguồn gốc của mọi tệ nạn là chủ nghĩa cá nhân. Trong bài “Nâng cao đạo đức cách mạng, quét sạch chủ nghĩa cá nhân” (1969), Người nhấn mạnh phải kiên quyết đấu tranh với chủ nghĩa cá nhân.
+
+c) Tu dưỡng đạo đức suốt đời
+- Tu dưỡng đạo đức là việc làm suốt đời, lâu dài, kiên trì, thường xuyên, liên tục.
+- Đạo đức không tự nhiên có, phải được rèn luyện trong thực tiễn công việc và các quan hệ xã hội.
+- Mỗi người phải tự giác nhìn thẳng vào mình, thấy rõ cái hay để phát huy, cái dở để khắc phục; không tự lừa dối, luôn nỗ lực hoàn thiện.
+
+Bảng so sánh đạo đức thông thường và đạo đức cách mạng
+
+| Tiêu chí | Đạo đức thông thường | Đạo đức cách mạng |
+| --- | --- | --- |
+| Cơ sở hình thành | Truyền thống, phong tục, tập quán, gia đình, cộng đồng | Hệ giá trị, lý tưởng cách mạng, mục tiêu quốc gia, dân tộc |
+| Phạm vi | Quan hệ cá nhân – gia đình – cộng đồng nhỏ | Quan hệ với dân tộc, nhân dân, xã hội, quốc tế |
+| Chuẩn mực chính | Hiếu thảo, trung thực, nhân ái, đoàn kết, giữ gìn nề nếp | Trung với nước, hiếu với dân; cần, kiệm, liêm, chính, chí công vô tư; thương yêu con người, tinh thần quốc tế trong sáng |
+| Tính chất | Mang tính ổn định, đề cao hòa khí, kế thừa truyền thống | Mang tính chiến đấu, hướng tới mục tiêu cách mạng, đề cao lý tưởng phụng sự nhân dân |
+
+Liên hệ với thực tiễn: xây dựng nhân cách cán bộ, giữ gìn uy tín Đảng
+- Cán bộ thực sự “cần, kiệm, liêm, chính, chí công vô tư”, tận tụy vì dân, nói đi đôi với làm sẽ tạo niềm tin, uy tín với quần chúng; nhân dân tin tưởng, đồng hành với chủ trương của Đảng, chính quyền.
+- Tổng Bí thư Nguyễn Phú Trọng là tấm gương nêu cao đạo đức, kiên quyết chống tham nhũng, kiên trì xây dựng “Đảng trong sạch, vững mạnh”.
+- Chiến dịch “đốt lò” xử lý hơn 200 cán bộ cấp cao giai đoạn 2016–2024, đưa ra ánh sáng các vụ Việt Á, “chuyến bay giải cứu”, Vạn Thịnh Phát, AIC, FLC, Tân Hoàng Minh... thể hiện quyết tâm chống suy thoái, củng cố niềm tin nhân dân.
+- Nhờ chú trọng đạo đức cách mạng, dám “chống cái xấu, xây cái tốt”, Đảng Cộng sản Việt Nam giữ được sức mạnh, khôi phục và củng cố niềm tin sau mỗi lần tự phê bình, xử lý sai phạm công khai, minh bạch.
+- Việc học tập, noi gương đạo đức Hồ Chí Minh, nâng cao đạo đức cách mạng cho cán bộ, đảng viên là yêu cầu sống còn đối với sự tồn vong của Đảng, sự phát triển bền vững của đất nước.
+`,
+            english: `
+Chapter 6: Hồ Chí Minh's Thought on Culture, Ethics, and Humanity
+
+3. Principles for cultivating revolutionary ethics
+
+a) Words must match deeds; lead by moral example
+- This is the foremost principle, uniting theory and practice—“Party members go first, the village follows.”
+- Hồ Chí Minh condemned hypocrisy: “Their mouths speak of democracy, yet they act like ‘mandarins’...”
+- He required cadres to set examples in spirit, material life, and culture: “First, set an example yourself...” (Collected Works, vol.4, p.171).
+- Cadres’ exemplary conduct is the most profound method of moral education; standards gain vitality only when they become everyday behaviour.
+
+b) Building must go hand in hand with combating
+- Building means cultivating new moral values and standards; combating means fighting degeneration, wrongdoing, and evil.
+- To build we must combat, and combating serves building; building remains primary as it awakens self-education and self-cultivation.
+- He identified individualism as the root of every vice. In “Heighten Revolutionary Ethics, Eliminate Individualism” (1969) he demanded resolute struggle against individualism.
+
+c) Lifelong moral cultivation
+- Moral cultivation is a lifelong, patient, persistent, and regular task.
+- Ethics do not arise naturally; they must be forged through work and social relationships.
+- Each person must consciously self-reflect, recognise strengths to promote and weaknesses to overcome; never deceive oneself, always strive for improvement.
+
+Comparison between ordinary morality and revolutionary ethics
+
+| Criterion | Ordinary morality | Revolutionary ethics |
+| --- | --- | --- |
+| Formation basis | Traditions, customs, family, community | Revolutionary values, ideals, national goals |
+| Scope | Personal, family, small-community relations | Relations with the nation, the people, society, and the world |
+| Core standards | Filial piety, honesty, compassion, solidarity, social order | Loyalty to the nation and devotion to the people; diligence, thrift, integrity, righteousness, absolute selflessness; love for humanity, pure international spirit |
+| Nature | Relatively stable, emphasising harmony and tradition | Combative, goal-oriented toward revolution, upholding the ideal of serving the people |
+
+Practical relevance: shaping cadres’ character and safeguarding Party prestige
+- Cadres who truly embody “diligence, thrift, integrity, righteousness, absolute selflessness,” devote themselves to the people, and match words with deeds will earn public trust and support for Party and state policies.
+- General Secretary Nguyễn Phú Trọng exemplifies ethical leadership, resolutely fighting corruption and persistently building a “pure, strong Party.”
+- The “blazing furnace” campaign disciplined over 200 high-ranking officials from 2016–2024 and exposed cases such as Việt Á, the “rescue flights,” Vạn Thịnh Phát, AIC, FLC, and Tân Hoàng Minh—demonstrating determination to curb moral decline and strengthen public confidence.
+- By prioritising revolutionary ethics and daring to “combat the bad, build the good,” the Communist Party of Vietnam maintains strength and restores trust after each transparent, public handling of violations.
+- Studying and emulating Hồ Chí Minh’s ethics, raising revolutionary morality among cadres and Party members, is vital to the Party’s survival and the nation’s sustainable development.
+`,
+        },
+        excerpt: {
+            vietnamese:
+                'Làm rõ ba nguyên tắc cốt lõi, bảng so sánh đạo đức cách mạng – thông thường và bài học thực tiễn trong công tác cán bộ.',
+            english:
+                'Clarifies three core principles, compares revolutionary and ordinary ethics, and links them to contemporary cadre work.',
+        },
+        author: 'Admin',
+        date: '2024-11-15',
+        readTime: {
+            vietnamese: '20 phút',
+            english: '20 minutes',
+        },
+        image: '/assets/blog-images/4.3.5-thumbnail.png',
+        originalLanguage: 'vietnamese' as const,
+    },
+} as const
 
 export type BlogData = typeof blogData
 export type BlogId = keyof BlogData
-export type Language = 'vietnamese' | 'english'

--- a/data/hcm-roadmap.ts
+++ b/data/hcm-roadmap.ts
@@ -1,0 +1,423 @@
+export type RoadmapEntry = {
+    id: string
+    stage: {
+        vietnamese: string
+        english: string
+    }
+    period: {
+        vietnamese: string
+        english: string
+    }
+    event: {
+        vietnamese: string
+        english: string
+    }
+    significance: {
+        vietnamese: string
+        english: string
+    }
+}
+
+export const roadmapEntries: RoadmapEntry[] = [
+    {
+        id: '1890-birth',
+        stage: {
+            vietnamese: 'Thời ấu thơ & nguồn cảm hứng ban đầu',
+            english: 'Childhood & early inspirations',
+        },
+        period: { vietnamese: '1890 (19/5)', english: '1890 (May 19)' },
+        event: {
+            vietnamese:
+                'Sinh ra tại làng Kim Liên, xã Nam Liên, huyện Nam Đàn, tỉnh Nghệ An với tên khai sinh Nguyễn Sinh Cung.',
+            english:
+                'Born in Kim Liên village, Nam Liên commune, Nam Đàn district, Nghệ An Province; birth name Nguyễn Sinh Cung.',
+        },
+        significance: {
+            vietnamese:
+                'Gia đình có truyền thống yêu nước, sống dưới ách đô hộ Pháp – bối cảnh hình thành nhận thức ban đầu về áp bức và bất công.',
+            english:
+                'Raised in a patriotic family under French colonial rule, shaping his first awareness of oppression and injustice.',
+        },
+    },
+    {
+        id: '1901-quoc-hoc',
+        stage: {
+            vietnamese: 'Thời ấu thơ & nguồn cảm hứng ban đầu',
+            english: 'Childhood & early inspirations',
+        },
+        period: {
+            vietnamese: '1901 – đầu thập niên 1900',
+            english: '1901 – early 1900s',
+        },
+        event: {
+            vietnamese:
+                'Bắt đầu dùng tên Nguyễn Tất Thành khi theo học tại Trường Quốc học Huế.',
+            english:
+                'Adopted the name Nguyễn Tất Thành while studying at Quốc Học Huế.',
+        },
+        significance: {
+            vietnamese:
+                'Thể hiện ý chí học hỏi, hình thành sớm ý thức dân tộc và khát vọng vươn lên.',
+            english:
+                'Showed a hunger for learning and an early sense of national consciousness and aspiration.',
+        },
+    },
+    {
+        id: '1911-departure',
+        stage: {
+            vietnamese: 'Giai đoạn ra đi tìm đường cứu nước',
+            english: 'Journey to find a path to national liberation',
+        },
+        period: { vietnamese: '05/6/1911', english: '5 June 1911' },
+        event: {
+            vietnamese:
+                'Rời cảng Nhà Rồng (Sài Gòn), lên tàu Đô đốc Latouche-Tréville với tên hiệu “Văn Ba”, bắt đầu hành trình bôn ba tìm đường cứu nước.',
+            english:
+                'Left Nhà Rồng wharf (Saigon) aboard the Latouche-Tréville under the alias “Văn Ba,” beginning his quest abroad for national salvation.',
+        },
+        significance: {
+            vietnamese:
+                'Bước ngoặt quyết định – từ trong nước bước ra thế giới để tìm đường giải phóng dân tộc.',
+            english:
+                'A decisive turning point, stepping onto the world stage to discover a strategy for liberating Vietnam.',
+        },
+    },
+    {
+        id: '1911-1920-work',
+        stage: {
+            vietnamese: 'Giai đoạn ra đi tìm đường cứu nước',
+            english: 'Journey to find a path to national liberation',
+        },
+        period: { vietnamese: '1911 – 1920', english: '1911 – 1920' },
+        event: {
+            vietnamese:
+                'Làm việc, sinh sống tại Pháp, Anh, Mỹ, châu Phi, châu Á; tiếp xúc phong trào công nhân và phong trào giải phóng dân tộc.',
+            english:
+                'Worked and lived in France, Britain, the United States, Africa, and Asia, engaging with labour and anti-colonial movements.',
+        },
+        significance: {
+            vietnamese:
+                'Trải nghiệm thực tiễn giúp thấm nhuần quyền lợi người lao động và sức mạnh quốc tế của cách mạng thuộc địa.',
+            english:
+                'These lived experiences deepened his understanding of workers’ rights and the global power of colonial liberation movements.',
+        },
+    },
+    {
+        id: '1919-petition',
+        stage: {
+            vietnamese: 'Giai đoạn ra đi tìm đường cứu nước',
+            english: 'Journey to find a path to national liberation',
+        },
+        period: { vietnamese: '1919', english: '1919' },
+        event: {
+            vietnamese:
+                'Dưới tên Nguyễn Ái Quốc, gửi “Yêu sách của nhân dân An Nam” tới Hội nghị Versailles, yêu cầu quyền tự do, dân chủ cho Việt Nam.',
+            english:
+                'As Nguyễn Ái Quốc, submitted the “Claims of the Annamite People” to the Versailles Conference, demanding freedom and democracy for Vietnam.',
+        },
+        significance: {
+            vietnamese:
+                'Đánh dấu bước chuyển từ hoạt động cá nhân sang đấu tranh chính trị trên trường quốc tế.',
+            english:
+                'Marked a shift from personal activism to international political advocacy for Vietnam.',
+        },
+    },
+    {
+        id: '1920-1930-communist',
+        stage: {
+            vietnamese: 'Giai đoạn ra đi tìm đường cứu nước',
+            english: 'Journey to find a path to national liberation',
+        },
+        period: { vietnamese: '1920 – 1930', english: '1920 – 1930' },
+        event: {
+            vietnamese:
+                'Tham gia các tổ chức cộng sản tại Pháp, tiến tới chuẩn bị cho việc thành lập Đảng Cộng sản ở Việt Nam.',
+            english:
+                'Joined communist organisations in France and prepared for the creation of the Communist Party in Vietnam.',
+        },
+        significance: {
+            vietnamese:
+                'Hoàn thiện lý luận cách mạng, kết nối phong trào cách mạng thế giới với Việt Nam.',
+            english:
+                'Consolidated revolutionary theory and linked Vietnam’s struggle with global movements.',
+        },
+    },
+    {
+        id: '1930-founding',
+        stage: {
+            vietnamese: 'Thành lập Đảng và lãnh đạo cách mạng trong nước',
+            english: 'Founding the Party & leading the domestic revolution',
+        },
+        period: { vietnamese: '03/02/1930', english: '3 February 1930' },
+        event: {
+            vietnamese:
+                'Chủ trì Hội nghị hợp nhất ba tổ chức cộng sản và thành lập Đảng Cộng sản Việt Nam tại Quảng Châu (Trung Quốc).',
+            english:
+                'Presided over the conference unifying three communist organisations to found the Communist Party of Vietnam in Guangzhou, China.',
+        },
+        significance: {
+            vietnamese:
+                'Xác lập vai trò lãnh đạo của Đảng đối với cách mạng Việt Nam.',
+            english:
+                'Established the Party’s leadership role over Vietnam’s revolution.',
+        },
+    },
+    {
+        id: '1941-pac-bo',
+        stage: {
+            vietnamese: 'Thành lập Đảng và lãnh đạo cách mạng trong nước',
+            english: 'Founding the Party & leading the domestic revolution',
+        },
+        period: { vietnamese: '08/2/1941', english: '8 February 1941' },
+        event: {
+            vietnamese:
+                'Bí mật về nước, đến Pắc Bó (Cao Bằng) để trực tiếp lãnh đạo phong trào Việt Minh.',
+            english:
+                'Secretly returned to Vietnam, arriving in Pác Bó (Cao Bằng) to directly lead the Việt Minh movement.',
+        },
+        significance: {
+            vietnamese:
+                'Chuyển sang lãnh đạo thực tiễn trên quê hương, xây dựng lực lượng kháng chiến.',
+            english:
+                'Signalled hands-on leadership within Vietnam and the organisation of resistance forces.',
+        },
+    },
+    {
+        id: '1945-august-revolution',
+        stage: {
+            vietnamese: 'Cách mạng Tháng Tám & nắm quyền lãnh đạo nhà nước',
+            english: 'August Revolution & leading the new state',
+        },
+        period: { vietnamese: '19/8/1945', english: '19 August 1945' },
+        event: {
+            vietnamese: 'Tổng khởi nghĩa giành chính quyền ở Hà Nội và trên cả nước.',
+            english: 'Led the general uprising to seize power in Hà Nội and nationwide.',
+        },
+        significance: {
+            vietnamese:
+                'Thắng lợi cách mạng dân tộc, chấm dứt ách thống trị thực dân.',
+            english:
+                'Achieved national revolutionary victory, ending colonial rule.',
+        },
+    },
+    {
+        id: '1945-independence',
+        stage: {
+            vietnamese: 'Cách mạng Tháng Tám & nắm quyền lãnh đạo nhà nước',
+            english: 'August Revolution & leading the new state',
+        },
+        period: { vietnamese: '02/9/1945', english: '2 September 1945' },
+        event: {
+            vietnamese:
+                'Đọc Tuyên ngôn Độc lập, khai sinh nước Việt Nam Dân chủ Cộng hòa.',
+            english:
+                'Proclaimed the Declaration of Independence, founding the Democratic Republic of Vietnam.',
+        },
+        significance: {
+            vietnamese:
+                'Biểu tượng quốc gia độc lập, đặt nền tảng cho nhà nước mới.',
+            english:
+                'Symbolised an independent nation and laid the foundation for the new state.',
+        },
+    },
+    {
+        id: '1946-president',
+        stage: {
+            vietnamese: 'Cách mạng Tháng Tám & nắm quyền lãnh đạo nhà nước',
+            english: 'August Revolution & leading the new state',
+        },
+        period: { vietnamese: '1946', english: '1946' },
+        event: {
+            vietnamese:
+                'Quốc hội khóa I bầu Hồ Chí Minh làm Chủ tịch nước và đảm nhiệm vai trò Thủ tướng giai đoạn đầu.',
+            english:
+                'The First National Assembly elected him President; he also served as Prime Minister in the early years.',
+        },
+        significance: {
+            vietnamese:
+                'Dựng nền móng nhà nước cách mạng, tổ chức bộ máy chính quyền từ trung ương đến địa phương.',
+            english:
+                'Built the foundations of the revolutionary state and organised government from central to local levels.',
+        },
+    },
+    {
+        id: '1946-1954-war',
+        stage: {
+            vietnamese: 'Kháng chiến chống Pháp & xây dựng miền Bắc',
+            english: 'Resistance against the French & building the North',
+        },
+        period: { vietnamese: '1946 – 1954', english: '1946 – 1954' },
+        event: {
+            vietnamese:
+                'Lãnh đạo cuộc kháng chiến toàn quốc chống thực dân Pháp, đỉnh cao là chiến thắng Điện Biên Phủ và Hiệp định Genève.',
+            english:
+                'Led the nationwide resistance against French colonialism, culminating in Điện Biên Phủ victory and the Geneva Accords.',
+        },
+        significance: {
+            vietnamese:
+                'Chấm dứt ách thống trị của Pháp tại Đông Dương, dù đất nước tạm thời bị chia cắt.',
+            english:
+                'Ended French domination in Indochina, though Vietnam was temporarily divided.',
+        },
+    },
+    {
+        id: '1955-1960-reform',
+        stage: {
+            vietnamese: 'Kháng chiến chống Pháp & xây dựng miền Bắc',
+            english: 'Resistance against the French & building the North',
+        },
+        period: { vietnamese: '1955 – 1960', english: '1955 – 1960' },
+        event: {
+            vietnamese:
+                'Miền Bắc tiến hành cách mạng xã hội chủ nghĩa: cải cách ruộng đất, hợp tác hóa nông nghiệp, xây dựng công nghiệp.',
+            english:
+                'The North advanced socialist transformation: land reform, agricultural collectivisation, and industrial development.',
+        },
+        significance: {
+            vietnamese:
+                'Thử nghiệm mô hình xã hội chủ nghĩa, tạo nền tảng kinh tế – xã hội mới.',
+            english:
+                'Tested the socialist model and laid new socio-economic foundations.',
+        },
+    },
+    {
+        id: '1951-congress-ii',
+        stage: {
+            vietnamese: 'Kháng chiến chống Pháp & xây dựng miền Bắc',
+            english: 'Resistance against the French & building the North',
+        },
+        period: { vietnamese: '1951', english: '1951' },
+        event: {
+            vietnamese:
+                'Đại hội lần II của Đảng bầu Hồ Chí Minh làm Chủ tịch Ban Chấp hành Trung ương.',
+            english:
+                'The Party’s Second Congress elected him Chairman of the Central Committee.',
+        },
+        significance: {
+            vietnamese:
+                'Củng cố vai trò lãnh đạo cá nhân và kiện toàn tổ chức Đảng.',
+            english:
+                'Strengthened his leadership role and consolidated the Party organisation.',
+        },
+    },
+    {
+        id: '1960-congress-iii',
+        stage: {
+            vietnamese: 'Kháng chiến chống Pháp & xây dựng miền Bắc',
+            english: 'Resistance against the French & building the North',
+        },
+        period: { vietnamese: '1960', english: '1960' },
+        event: {
+            vietnamese:
+                'Đại hội lần III tiếp tục tín nhiệm ông vào các chức vụ chủ chốt của Đảng.',
+            english:
+                'The Third Party Congress reaffirmed him in the Party’s top leadership positions.',
+        },
+        significance: {
+            vietnamese:
+                'Đảm bảo tính liên tục và nhất quán của đường lối cách mạng.',
+            english:
+                'Ensured continuity and consistency in revolutionary strategy.',
+        },
+    },
+    {
+        id: '1955-1969-war',
+        stage: {
+            vietnamese: 'Kháng chiến chống Mỹ – cứu nước & chuẩn bị hòa bình',
+            english: 'Resistance against the US & preparing for peace',
+        },
+        period: { vietnamese: '1955 – 1969', english: '1955 – 1969' },
+        event: {
+            vietnamese:
+                'Lãnh đạo kháng chiến chống Mỹ ở miền Nam thông qua Mặt trận Dân tộc Giải phóng miền Nam.',
+            english:
+                'Directed the resistance against the United States in the South via the National Liberation Front.',
+        },
+        significance: {
+            vietnamese:
+                'Tiếp tục mục tiêu thống nhất đất nước và bảo vệ chủ nghĩa xã hội.',
+            english:
+                'Pursued national reunification and defended socialism.',
+        },
+    },
+    {
+        id: '1965-health',
+        stage: {
+            vietnamese: 'Kháng chiến chống Mỹ – cứu nước & chuẩn bị hòa bình',
+            english: 'Resistance against the US & preparing for peace',
+        },
+        period: { vietnamese: '1965 trở đi', english: 'From 1965 onward' },
+        event: {
+            vietnamese:
+                'Do sức khỏe giảm sút, ông giảm dần sự can dự trực tiếp vào công việc lãnh đạo hàng ngày.',
+            english:
+                'As his health declined, he gradually reduced direct involvement in day-to-day leadership.',
+        },
+        significance: {
+            vietnamese:
+                'Chuyển giao trách nhiệm, đào tạo lớp kế thừa trong Đảng và Nhà nước.',
+            english:
+                'Facilitated leadership transition and mentored successors within the Party and state.',
+        },
+    },
+    {
+        id: '1965-1969-testament',
+        stage: {
+            vietnamese: 'Kháng chiến chống Mỹ – cứu nước & chuẩn bị hòa bình',
+            english: 'Resistance against the US & preparing for peace',
+        },
+        period: { vietnamese: '1965 – 1969', english: '1965 – 1969' },
+        event: {
+            vietnamese:
+                'Viết bản Di chúc, căn dặn nhiệm vụ của Đảng và dân tộc, nhấn mạnh đoàn kết và tình yêu thương con người.',
+            english:
+                'Wrote his Testament, outlining Party and national duties and emphasising unity and human compassion.',
+        },
+        significance: {
+            vietnamese:
+                'Di chúc trở thành nguồn tư tưởng căn bản, định hướng Tư tưởng Hồ Chí Minh về sau.',
+            english:
+                'The Testament became a foundational source guiding Hồ Chí Minh Thought in later years.',
+        },
+    },
+    {
+        id: '1969-passing',
+        stage: {
+            vietnamese: 'Qua đời & di sản',
+            english: 'Passing & legacy',
+        },
+        period: { vietnamese: '02/9/1969', english: '2 September 1969' },
+        event: {
+            vietnamese: 'Qua đời tại Hà Nội, thọ 79 tuổi.',
+            english: 'Passed away in Hà Nội at the age of 79.',
+        },
+        significance: {
+            vietnamese:
+                'Khép lại hành trình cách mạng cá nhân, để lại di sản tư tưởng và hình tượng lãnh tụ.',
+            english:
+                'Closed his revolutionary journey, leaving a profound intellectual and leadership legacy.',
+        },
+    },
+    {
+        id: '1973-1975-mausoleum',
+        stage: {
+            vietnamese: 'Qua đời & di sản',
+            english: 'Passing & legacy',
+        },
+        period: { vietnamese: '1973 – 1975', english: '1973 – 1975' },
+        event: {
+            vietnamese:
+                'Xây dựng Lăng Chủ tịch Hồ Chí Minh và đưa thi hài Người vào bảo quản; khánh thành năm 1975.',
+            english:
+                'Constructed Hồ Chí Minh’s Mausoleum to preserve his body; inaugurated in 1975.',
+        },
+        significance: {
+            vietnamese:
+                'Tôn vinh lãnh tụ, tạo biểu tượng quốc gia về đoàn kết và lòng biết ơn.',
+            english:
+                'Honoured the leader, creating a national symbol of unity and gratitude.',
+        },
+    },
+]
+
+export type RoadmapData = typeof roadmapEntries

--- a/data/philosophy-chapters.ts
+++ b/data/philosophy-chapters.ts
@@ -1,92 +1,38 @@
-// philosophy-chapters.ts (Chapter 4 only, VI/EN; removed Japanese)
+// philosophy-chapters.ts (Chapter 6 only, VI/EN)
 
 export const philosophyBlogs = {
-  '4.1': {
+  '6': {
     title: {
-      vietnamese: 'Dân chủ và dân chủ xã hội chủ nghĩa',
-      english: 'Democracy and Socialist Democracy',
+      vietnamese: 'Chương 6: Tư tưởng Hồ Chí Minh về văn hóa, đạo đức, con người',
+      english: "Chapter 6: Hồ Chí Minh's Thought on Culture, Ethics, and Humanity",
     },
-    sections: ['4.1.1', '4.1.2'],
-  },
-  '4.2': {
-    title: {
-      vietnamese: 'Nhà nước xã hội chủ nghĩa',
-      english: 'The Socialist State',
-    },
-    sections: ['4.2'],
-  },
-  '4.3': {
-    title: {
-      vietnamese: 'Dân chủ XHCN và nhà nước pháp quyền XHCN ở Việt Nam',
-      english: 'Socialist Democracy & the Socialist Rule-of-Law State in Vietnam',
-    },
-    sections: ['4.3.1','4.3.2','4.3.3','4.3.4','4.3.5'],
+    sections: ['6.1', '6.2', '6.3'],
   },
 } as const
 
 export type ChapterId = keyof typeof philosophyBlogs
 
 export const philosophySections = {
-  // Chương I
-  '4.1.1': {
+  '6.1': {
     title: {
-      vietnamese: 'Dân chủ và sự ra đời, phát triển của dân chủ',
-      english: 'Democracy: Emergence and Development',
+      vietnamese: 'Đạo đức – gốc rễ của người cách mạng',
+      english: 'Ethics – the revolutionary foundation',
     },
-    blog: '4.1',
+    blog: '6',
   },
-  '4.1.2': {
+  '6.2': {
     title: {
-      vietnamese: 'Dân chủ xã hội chủ nghĩa',
-      english: 'Socialist Democracy',
+      vietnamese: 'Chuẩn mực đạo đức cách mạng',
+      english: 'Standards of revolutionary ethics',
     },
-    blog: '4.1',
+    blog: '6',
   },
-
-  // Chương II
-  '4.2': {
+  '6.3': {
     title: {
-      vietnamese: 'Nhà nước xã hội chủ nghĩa',
-      english: 'The Socialist State',
+      vietnamese: 'Nguyên tắc tu dưỡng và vận dụng thực tiễn',
+      english: 'Principles of cultivation and practical application',
     },
-    blog: '4.2',
-  },
-
-  // Chương III
-  '4.3.1': {
-    title: {
-      vietnamese: 'Dân chủ xã hội chủ nghĩa ở Việt Nam',
-      english: 'Socialist Democracy in Vietnam',
-    },
-    blog: '4.3',
-  },
-  '4.3.2': {
-    title: {
-      vietnamese: 'Nhà nước pháp quyền xã hội chủ nghĩa ở Việt Nam',
-      english: 'The Socialist Rule-of-Law State in Vietnam',
-    },
-    blog: '4.3',
-  },
-  '4.3.3': {
-    title: {
-      vietnamese: 'Phát huy dân chủ, xây dựng Nhà nước pháp quyền XHCN hiện nay',
-      english: 'Promote Democracy & Build the Socialist Rule-of-Law State Today',
-    },
-    blog: '4.3',
-  },
-  '4.3.4': {
-    title: {
-      vietnamese: 'Phòng, chống tham nhũng góp phần bảo vệ chế độ, xây dựng Nhà nước pháp quyền',
-      english: 'Anti-Corruption to Safeguard the Regime & Build the Rule-of-Law State',
-    },
-    blog: '4.3',
-  },
-  '4.3.5': {
-    title: {
-      vietnamese: 'Trách nhiệm của công dân trong phòng, chống tham nhũng',
-      english: 'Citizen Responsibility in Anti-Corruption',
-    },
-    blog: '4.3',
+    blog: '6',
   },
 } as const
 

--- a/data/translations.ts
+++ b/data/translations.ts
@@ -9,20 +9,40 @@ export const translations = {
 
   home: {
     exploreBlogs: {
-      vietnamese: 'Khám phá các chương triết học',
-      english: 'Explore philosophy chapters',
+      vietnamese: 'Khám phá chiều sâu Chương 6',
+      english: 'Explore the depth of Chapter 6',
     },
     title: { vietnamese: 'E-Learning', english: 'E-Learning' },
     subtitle: {
-      vietnamese: 'Khám phá thế giới triết học qua những bài viết sâu sắc và tương tác',
-      english: 'Explore the world of philosophy through in-depth and interactive articles',
+      vietnamese: 'Khám phá tư tưởng Hồ Chí Minh về văn hóa, đạo đức và con người',
+      english: "Explore Hồ Chí Minh's reflections on culture, ethics, and humanity",
     },
     heroDescription: {
-      vietnamese: 'Nền tảng học triết học Marxist với AI assistant, quiz tương tác và nội dung song ngữ',
-      english: 'Marxist philosophy learning platform with an AI assistant, interactive quizzes, and bilingual content',
+      vietnamese: 'Nền tảng học tập chuyên sâu về đạo đức cách mạng với trợ lý AI, bài viết song ngữ và quiz tương tác',
+      english: 'A focused hub on revolutionary ethics with an AI assistant, bilingual articles, and interactive quizzes',
     },
     readBlog: { vietnamese: 'Nội dung', english: 'Contents' },
     takeQuiz: { vietnamese: 'Làm quiz', english: 'Take quiz' },
+    roadmapTitle: {
+      vietnamese: 'Cuộc đời & sự nghiệp của Hồ Chí Minh',
+      english: 'Life & career of Hồ Chí Minh',
+    },
+    roadmapDescription: {
+      vietnamese: 'Theo dõi hành trình từ tuổi thơ, ra đi tìm đường cứu nước đến di sản để lại cho dân tộc.',
+      english: 'Trace his journey from childhood and the overseas quest for liberation to the legacy he left the nation.',
+    },
+    roadmapHint: {
+      vietnamese: 'Chạm vào các mốc thời gian để xem sự kiện và đóng góp nổi bật.',
+      english: 'Tap each milestone to reveal the key events and contributions.',
+    },
+    roadmapEventLabel: {
+      vietnamese: 'Sự kiện / Hoạt động chính',
+      english: 'Key event / activity',
+    },
+    roadmapImpactLabel: {
+      vietnamese: 'Ý nghĩa / Đóng góp nổi bật',
+      english: 'Significance / key contribution',
+    },
     articlesCount: { vietnamese: 'Bài viết triết học', english: 'Philosophy articles' },
     languagesSupported: { vietnamese: 'Ngôn ngữ hỗ trợ', english: 'Languages supported' },
     quizQuestions: { vietnamese: 'Câu hỏi quiz', english: 'Quiz questions' },
@@ -35,36 +55,20 @@ export const translations = {
     weeklyUpdates: { vietnamese: 'Được cập nhật hàng tuần', english: 'Updated weekly' },
     languageSupport: { vietnamese: 'Vi, En', english: 'Vi, En' },
     interactiveQuiz: { vietnamese: 'Quiz tương tác', english: 'Interactive quiz' },
-    chapter41Title: {
-      vietnamese: 'Chương 4.1: Dân chủ và dân chủ xã hội chủ nghĩa',
-      english: 'Chapter 4.1: Democracy & Socialist Democracy',
+    chapter6Title: {
+      vietnamese: 'Chương 6: Tư tưởng Hồ Chí Minh về văn hóa, đạo đức, con người',
+      english: "Chapter 6: Hồ Chí Minh's Thought on Culture, Ethics, and Humanity",
     },
-    chapter41Description: {
-      vietnamese: 'Tìm hiểu nguồn gốc, bản chất và giá trị của nền dân chủ xã hội chủ nghĩa.',
-      english: 'Discover the origins, nature, and values of socialist democracy.',
-    },
-    chapter42Title: {
-      vietnamese: 'Chương 4.2: Nhà nước xã hội chủ nghĩa',
-      english: 'Chapter 4.2: The Socialist State',
-    },
-    chapter42Description: {
-      vietnamese: 'Khám phá cấu trúc, chức năng và vai trò lịch sử của nhà nước xã hội chủ nghĩa.',
-      english: 'Explore the structure, functions, and historical role of the socialist state.',
-    },
-    chapter43Title: {
-      vietnamese: 'Chương 4.3: Dân chủ XHCN & Nhà nước pháp quyền ở Việt Nam',
-      english: 'Chapter 4.3: Socialist Democracy & Rule-of-Law State in Vietnam',
-    },
-    chapter43Description: {
-      vietnamese: 'Liên hệ thực tiễn Việt Nam trong xây dựng dân chủ và nhà nước pháp quyền XHCN.',
-      english: 'Connect Vietnam’s practice in building socialist democracy and a rule-of-law state.',
+    chapter6Description: {
+      vietnamese: 'Tìm hiểu đạo đức cách mạng, bảng so sánh chuẩn mực và liên hệ công tác cán bộ hiện nay.',
+      english: 'Study revolutionary ethics, comparative standards, and their relevance to today’s cadre work.',
     },
     explore: { vietnamese: 'Khám phá', english: 'Explore' },
     articles: { vietnamese: 'bài viết', english: 'articles' },
     viewAll: { vietnamese: 'Xem tất cả', english: 'View all' },
     featuredPostsDescription: {
-      vietnamese: 'Những bài viết triết học mới nhất và được yêu thích nhất',
-      english: 'Latest and most popular philosophy articles',
+      vietnamese: 'Bài viết chuyên sâu về đạo đức Hồ Chí Minh và thực tiễn vận dụng',
+      english: "In-depth writing on Hồ Chí Minh's ethics and its practical application",
     },
   },
 
@@ -119,6 +123,10 @@ export const translations = {
     retakeQuiz: { vietnamese: 'Làm lại Quiz', english: 'Retake quiz' },
     question: { vietnamese: 'Câu', english: 'Question' },
     nextQuestion: { vietnamese: 'Câu tiếp theo', english: 'Next question' },
+    previousQuestion: {
+      vietnamese: 'Quay lại câu trước',
+      english: 'Back to previous question',
+    },
     complete: { vietnamese: 'Hoàn thành', english: 'Complete' },
     noQuizAvailable: { vietnamese: 'Không có Quiz khả dụng', english: 'No quiz available' },
     noQuizQuestionsMessage: {
@@ -130,6 +138,7 @@ export const translations = {
       english: 'Back to quiz overview',
     },
     quizForChapter: { vietnamese: 'Quiz cho Chương', english: 'Quiz for Chapter' },
+    partLabel: { vietnamese: 'Phần', english: 'Part' },
   },
 
   chat: {
@@ -151,8 +160,8 @@ export const translations = {
     publishedOn: { vietnamese: 'Xuất bản ngày', english: 'Published on' },
     allArticles: { vietnamese: 'Tất cả bài viết', english: 'All articles' },
     exploreCollection: {
-      vietnamese: 'Khám phá bộ sưu tập đầy đủ các bài viết của Chương 4',
-      english: 'Explore the full collection of Chapter 4 articles',
+      vietnamese: 'Khám phá toàn bộ nội dung của Chương 6',
+      english: 'Explore the complete Chapter 6 collection',
     },
     noArticlesFound: {
       vietnamese: 'Không tìm thấy bài viết nào',
@@ -276,12 +285,12 @@ export const translations = {
 
   blogPage: {
     heroTitle: {
-      vietnamese: 'Thư viện triết học Chương 4',
-      english: 'Chapter 4 philosophy library',
+      vietnamese: 'Thư viện triết học Chương 6',
+      english: 'Chapter 6 philosophy library',
     },
     heroDescription: {
-      vietnamese: 'Bộ sưu tập đầy đủ các bài viết về dân chủ và nhà nước xã hội chủ nghĩa.',
-      english: 'A complete collection of articles on socialist democracy and the socialist state.',
+      vietnamese: 'Bộ sưu tập nội dung về tư tưởng Hồ Chí Minh đối với đạo đức và con người.',
+      english: "A curated collection on Hồ Chí Minh's ethics and human development.",
     },
     filterAndSearch: {
       vietnamese: 'Lọc & tìm kiếm',


### PR DESCRIPTION
## Summary
- split chapter quizzes into two 10-question sections and label each part
- enhance the quiz component with answer persistence and a back-to-previous-question button
- add localized strings for the new quiz controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db24076ed08328b72ffdf9a5a8364b